### PR TITLE
ci(deploy): automate development UI release

### DIFF
--- a/.github/workflows/deploy-development-ui.yml
+++ b/.github/workflows/deploy-development-ui.yml
@@ -1,0 +1,104 @@
+name: Deploy development UI
+
+on:
+  push:
+    branches:
+      - development
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-development-ui
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: development
+      url: https://dev.veolms.org
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 11.18.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type-check web application
+        run: pnpm --filter @veolms/web typecheck
+
+      - name: Run web unit tests
+        run: pnpm --filter @veolms/web test:unit
+
+      - name: Build web application without an external media base URL
+        if: ${{ vars.VITE_COURSE_MEDIA_BASE_URL == '' }}
+        run: pnpm build:web
+
+      - name: Build web application with the configured media base URL
+        if: ${{ vars.VITE_COURSE_MEDIA_BASE_URL != '' }}
+        run: pnpm build:web
+        env:
+          VITE_COURSE_MEDIA_BASE_URL: ${{ vars.VITE_COURSE_MEDIA_BASE_URL }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+          allowed-account-ids: ${{ vars.AWS_ACCOUNT_ID }}
+          role-session-name: veolms-development-ui-${{ github.run_id }}
+
+      - name: Upload application assets to S3
+        shell: bash
+        env:
+          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
+        run: |
+          aws s3 sync apps/web/build/client "s3://${AWS_S3_BUCKET}" \
+            --delete \
+            --exclude "index.html" \
+            --cache-control "public,max-age=300,must-revalidate" \
+            --only-show-errors
+
+      - name: Upload entry document last
+        shell: bash
+        env:
+          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
+        run: |
+          aws s3 cp apps/web/build/client/index.html "s3://${AWS_S3_BUCKET}/index.html" \
+            --cache-control "no-cache,no-store,must-revalidate" \
+            --content-type "text/html; charset=utf-8" \
+            --only-show-errors
+
+      - name: Invalidate CloudFront cache
+        shell: bash
+        env:
+          AWS_CLOUDFRONT_DISTRIBUTION_ID: ${{ vars.AWS_CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          invalidation_id="$(aws cloudfront create-invalidation \
+            --distribution-id "${AWS_CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/*" \
+            --query 'Invalidation.Id' \
+            --output text)"
+
+          aws cloudfront wait invalidation-completed \
+            --distribution-id "${AWS_CLOUDFRONT_DISTRIBUTION_ID}" \
+            --id "${invalidation_id}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -74,7 +74,13 @@ wsl --shutdown
 
 ## Run the applications
 
-The Web application runs at `http://localhost:3000` and proxies `/api` requests to the API at `http://localhost:4000`. Set `WEB_PORT` in `.env` to override the frontend port. `pnpm dev` starts only Web and API; the fleet manager and media worker remain inactive shells.
+The Web application currently runs independently of the API and database. Start only the frontend with:
+
+```bash
+pnpm dev:web
+```
+
+It is available at `http://localhost:3000`. Set `WEB_PORT` in `.env` to override the frontend port. Use `pnpm dev` only when developing the Web and API applications together; the fleet manager and media worker remain inactive shells.
 
 API logs are formatted for readability in development by default. Set `API_DEV_PRETTY_LOGS=false` in `.env` to keep the original JSON log format. This setting is development-only; production logs always remain structured JSON.
 
@@ -88,11 +94,26 @@ The document lists `/` as its server, which resolves against whatever origin ser
 
 ## Static Web build
 
-The static build requires PostgreSQL to be healthy, migrations and seed data to be present, and the API to be running:
+The static Web build does not require PostgreSQL or the API. Build and preview it with:
 
 ```bash
-pnpm dev:api
 pnpm build:web
+pnpm --filter @veolms/web preview
 ```
 
-During the build, React Router uses `STATIC_BUILD_API_URL` to discover published course slugs and fetch their content. It writes deployable static files, including one HTML page per course, to `apps/web/build/client`. Browser navigation continues to use the relative `VITE_API_BASE_URL` path.
+React Router writes the deployable client-only application to `apps/web/build/client`. `VITE_COURSE_MEDIA_BASE_URL` is optional; when it is unset, course media uses relative `/course-videos/...` URLs.
+
+## Development UI deployment
+
+Every push to `development` runs `.github/workflows/deploy-development-ui.yml`. The workflow type-checks and tests the Web application, builds it, synchronises `apps/web/build/client` to S3, uploads `index.html` last with a no-cache policy, and waits for a CloudFront `/*` invalidation to finish. It can also be started manually from GitHub Actions.
+
+The workflow uses the GitHub `development` environment and exchanges GitHub's OIDC token for short-lived AWS credentials. Configure these GitHub Actions variables on that environment:
+
+- `AWS_DEPLOY_ROLE_ARN`
+- `AWS_ACCOUNT_ID`
+- `AWS_REGION`
+- `AWS_S3_BUCKET`
+- `AWS_CLOUDFRONT_DISTRIBUTION_ID`
+- `VITE_COURSE_MEDIA_BASE_URL` (optional)
+
+Do not add long-lived AWS access keys as GitHub secrets. Restrict the role's trust policy to the repository's immutable `development` environment subject, `repo:veolms@301170291/veolms@1320067532:environment:development`. Its permissions should be limited to listing the deployment bucket, putting and deleting objects in that bucket, and creating and reading invalidations for the development CloudFront distribution.


### PR DESCRIPTION
## Summary

- add a development-only UI deployment workflow using GitHub OIDC
- run frontend type-checks, unit tests, and a production build before deployment
- sync the static client build to S3, publish index.html last, and wait for CloudFront invalidation
- document frontend-only builds and deployment variables

## Validation

- 18 unit test files / 97 tests passed
- web type-check passed
- production build passed
- Prettier and git diff checks passed

## Infrastructure status

The GitHub development environment, branch restriction, S3/distribution variables, and ACM certificate request are prepared. The AWS OIDC role and GoDaddy DNS records are pending explicit infrastructure approval/authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated deployment of the development web interface after changes are pushed or manually triggered.
  * Added support for building and previewing the web interface independently from the API and database.
  * Added optional configuration for relative course-media URLs.

* **Documentation**
  * Documented standalone web development, builds, previews, and automated deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->