### PR TITLE
fix(deploy): preserve course media assets

### DIFF
--- a/.github/workflows/deploy-development-ui.yml
+++ b/.github/workflows/deploy-development-ui.yml
@@ -75,6 +75,8 @@ jobs:
           aws s3 sync apps/web/build/client "s3://${AWS_S3_BUCKET}" \
             --delete \
             --exclude "index.html" \
+            --exclude "course-videos/" \
+            --exclude "course-videos/*" \
             --cache-control "public,max-age=300,must-revalidate" \
             --only-show-errors
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -105,7 +105,7 @@ React Router writes the deployable client-only application to `apps/web/build/cl
 
 ## Development UI deployment
 
-Every push to `development` runs `.github/workflows/deploy-development-ui.yml`. The workflow type-checks and tests the Web application, builds it, synchronises `apps/web/build/client` to S3, uploads `index.html` last with a no-cache policy, and waits for a CloudFront `/*` invalidation to finish. It can also be started manually from GitHub Actions.
+Every push to `development` runs `.github/workflows/deploy-development-ui.yml`. The workflow type-checks and tests the Web application, builds it, synchronises `apps/web/build/client` to S3 while preserving the separately managed `course-videos/` prefix, uploads `index.html` last with a no-cache policy, and waits for a CloudFront `/*` invalidation to finish. It can also be started manually from GitHub Actions.
 
 The workflow uses the GitHub `development` environment and exchanges GitHub's OIDC token for short-lived AWS credentials. Configure these GitHub Actions variables on that environment:
 


### PR DESCRIPTION
## Summary

- preserve the separately managed `course-videos/` S3 prefix during UI deployment
- document the deployment ownership boundary

## Validation

- Prettier passed
- `git diff --check` passed
- S3 sync dry-run planned zero course-media deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated development UI deployments to preserve separately managed course video assets during application asset synchronization.

* **Documentation**
  * Clarified that the course video asset directory is excluded from development UI deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->