### PR TITLE
chore: add pnpm catalog for shared deps (zod, kysely, @typescript/native)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,10 +20,10 @@
     "@veolms/database": "workspace:*",
     "fastify": "^5.11.0",
     "fastify-type-provider-zod": "^7.0.0",
-    "kysely": "^0.29.4",
+    "kysely": "catalog:",
     "nodemailer": "^9.0.5",
     "openapi-types": "^12.1.3",
-    "zod": "^4.4.3"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/nodemailer": "^8.0.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
-    "@typescript/native": "npm:typescript@7.0.2",
+    "@typescript/native": "catalog:",
     "jsdom": "^30.0.1",
     "tailwindcss": "^4.3.3",
     "vite": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@typescript/native": "npm:typescript@^7.0.2",
+    "@typescript/native": "catalog:",
     "@types/node": "^24.10.13",
     "eslint": "^9.39.2",
     "eslint-plugin-react": "^7.37.5",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -8,6 +8,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "zod": "^4.4.3"
+    "zod": "catalog:"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -8,6 +8,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "zod": "^4.4.3"
+    "zod": "catalog:"
   }
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@veolms/config": "workspace:*",
     "@veolms/contracts": "workspace:*",
-    "kysely": "^0.29.4",
+    "kysely": "catalog:",
     "pg": "^8.22.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@typescript/native':
+      specifier: npm:typescript@^7.0.2
+      version: 7.0.2
+    kysely:
+      specifier: ^0.29.4
+      version: 0.29.4
+    zod:
+      specifier: ^4.4.3
+      version: 4.4.3
+
 importers:
 
   .:
@@ -15,7 +27,7 @@ importers:
         specifier: ^24.10.13
         version: 24.13.3
       '@typescript/native':
-        specifier: npm:typescript@^7.0.2
+        specifier: 'catalog:'
         version: typescript@7.0.2
       eslint:
         specifier: ^9.39.2
@@ -78,7 +90,7 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0(@fastify/swagger@9.8.1(supports-color@7.2.0))(fastify@5.11.0)(openapi-types@12.1.3)(zod@4.4.3)
       kysely:
-        specifier: ^0.29.4
+        specifier: 'catalog:'
         version: 0.29.4
       nodemailer:
         specifier: ^9.0.5
@@ -87,7 +99,7 @@ importers:
         specifier: ^12.1.3
         version: 12.1.3
       zod:
-        specifier: ^4.4.3
+        specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
       '@types/nodemailer':
@@ -153,7 +165,7 @@ importers:
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
       '@typescript/native':
-        specifier: npm:typescript@7.0.2
+        specifier: 'catalog:'
         version: typescript@7.0.2
       jsdom:
         specifier: ^30.0.1
@@ -171,13 +183,13 @@ importers:
   packages/config:
     dependencies:
       zod:
-        specifier: ^4.4.3
+        specifier: 'catalog:'
         version: 4.4.3
 
   packages/contracts:
     dependencies:
       zod:
-        specifier: ^4.4.3
+        specifier: 'catalog:'
         version: 4.4.3
 
   packages/database:
@@ -189,7 +201,7 @@ importers:
         specifier: workspace:*
         version: link:../contracts
       kysely:
-        specifier: ^0.29.4
+        specifier: 'catalog:'
         version: 0.29.4
       pg:
         specifier: ^8.22.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,11 @@ packages:
   - "apps/*"
   - "packages/*"
 
+catalog:
+  zod: "^4.4.3"
+  kysely: "^0.29.4"
+  "@typescript/native": "npm:typescript@^7.0.2"
+
 onlyBuiltDependencies: []
 
 # Turbo starts persistent workspace scripts concurrently. Keep dependency


### PR DESCRIPTION
## Summary

Introduces a [pnpm catalog](https://pnpm.io/catalogs) in `pnpm-workspace.yaml` to enforce a single source of truth for dependencies that are shared across **2 or more** packages/apps.

## Catalog entries

| Dependency | Shared by | Count |
|---|---|---|
| `zod` | `@veolms/config`, `@veolms/contracts`, `@veolms/api` | 3 |
| `kysely` | `@veolms/api`, `@veolms/database` | 2 |
| `@typescript/native` | root `package.json`, `@veolms/web` | 2 |

## Files changed

- `pnpm-workspace.yaml` — added `catalog:` block
- `package.json` — `@typescript/native` → `catalog:`
- `apps/api/package.json` — `zod`, `kysely` → `catalog:`
- `apps/web/package.json` — `@typescript/native` → `catalog:`
- `packages/config/package.json` — `zod` → `catalog:`
- `packages/contracts/package.json` — `zod` → `catalog:`
- `packages/database/package.json` — `kysely` → `catalog:`

Single-use dependencies are left with explicit versions in their own `package.json` to avoid unnecessary catalog bloat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized shared dependency versions for improved consistency across the application.
  * Standardized TypeScript, validation, and database library version management.
  * Updated workspace configuration to use a shared dependency catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->