### PR TITLE
feat(VideoPlayer): support single long-press for 2x speed (fixes #19)

### DIFF
--- a/apps/web/src/VideoPlayer.tsx
+++ b/apps/web/src/VideoPlayer.tsx
@@ -111,7 +111,11 @@ export function VideoPlayer({
   const hudTimerRef = useRef<number | undefined>(undefined);
   const lastResumePersistedAtRef = useRef<number | null>(null);
   const lastKnownPlaybackTimeRef = useRef(0);
-  const shortcutHandlerRef = useRef<(event: KeyboardEvent) => void>(() => {});
+  const shortcutHandlerRef = useRef<(event: KeyboardEvent) => void>(() => { });
+  const shortcutUpHandlerRef = useRef<(event: KeyboardEvent) => void>(() => { });
+  const lastClickTimeRef = useRef(0);
+  const wasPausedBeforeSpeedBoostRef = useRef(false);
+  const longPressTimerRef = useRef<number | undefined>(undefined);
 
   const [playing, setPlaying] = useState(false);
   const [muted, setMuted] = useState(false);
@@ -130,6 +134,7 @@ export function VideoPlayer({
   // The server cannot read the saved device preference. Start from the same
   // deterministic value on both sides, then restore it after hydration.
   const [ambient, setAmbient] = useState(false);
+  const [tempSpeedActive, setTempSpeedActive] = useState(false);
 
   const showHud = (message: string) => {
     window.clearTimeout(hudTimerRef.current);
@@ -300,16 +305,47 @@ export function VideoPlayer({
   };
 
   const handleFramePointerDown = (event: ReactPointerEvent<HTMLElement>) => {
-    if (!settingsOpen) return;
-    const target = event.target;
-    if (
-      settingsMenuRef.current?.contains(target as Node) ||
-      settingsButtonRef.current?.contains(target as Node)
-    )
+    if (settingsOpen) {
+      const target = event.target;
+      if (
+        settingsMenuRef.current?.contains(target as Node) ||
+        settingsButtonRef.current?.contains(target as Node)
+      )
+        return;
+      suppressNextPlayerActionRef.current = true;
+      setSettingsOpen(false);
+      setSettingsPage("main");
       return;
-    suppressNextPlayerActionRef.current = true;
-    setSettingsOpen(false);
-    setSettingsPage("main");
+    }
+
+    const now = Date.now();
+    if (now - lastClickTimeRef.current < 400) {
+      setTempSpeedActive(true);
+      wasPausedBeforeSpeedBoostRef.current = videoRef.current?.paused ?? false;
+      if (videoRef.current?.paused) {
+        void videoRef.current.play().catch(() => { });
+      }
+    } else {
+      longPressTimerRef.current = window.setTimeout(() => {
+        setTempSpeedActive(true);
+        wasPausedBeforeSpeedBoostRef.current = videoRef.current?.paused ?? false;
+        if (videoRef.current?.paused) {
+          void videoRef.current.play().catch(() => { });
+        }
+      }, 500);
+    }
+    lastClickTimeRef.current = now;
+  };
+
+  const clearTempSpeed = () => {
+    window.clearTimeout(longPressTimerRef.current);
+    if (tempSpeedActive) {
+      setTempSpeedActive(false);
+      if (wasPausedBeforeSpeedBoostRef.current) {
+        videoRef.current?.pause();
+      }
+      suppressNextPlayerActionRef.current = true;
+    }
   };
 
   useEffect(() => {
@@ -341,8 +377,8 @@ export function VideoPlayer({
   }, [autoPlayOnMediaChange, media.duration, media.src]);
 
   useEffect(() => {
-    if (videoRef.current) videoRef.current.playbackRate = speed;
-  }, [speed]);
+    if (videoRef.current) videoRef.current.playbackRate = tempSpeedActive ? 2 : speed;
+  }, [speed, tempSpeedActive]);
 
   useEffect(() => {
     if (videoRef.current) videoRef.current.volume = volume;
@@ -508,7 +544,18 @@ export function VideoPlayer({
       return;
     }
 
-    if (event.code === "Space" || key === "k") {
+    if (event.code === "Space") {
+      event.preventDefault();
+      if (event.repeat) {
+        if (!tempSpeedActive) {
+          setTempSpeedActive(true);
+          wasPausedBeforeSpeedBoostRef.current = videoRef.current?.paused ?? false;
+          if (videoRef.current?.paused) {
+            void videoRef.current.play().catch(() => { });
+          }
+        }
+      }
+    } else if (key === "k") {
       event.preventDefault();
       void togglePlay();
     } else if (event.code === "ArrowLeft") {
@@ -548,12 +595,38 @@ export function VideoPlayer({
   };
   shortcutHandlerRef.current = handlePlayerKeyDown;
 
+  const handlePlayerKeyUp = (event: KeyboardEvent) => {
+    if (
+      event.isComposing ||
+      isEditingShortcutTarget(event.target)
+    )
+      return;
+
+    if (event.code === "Space") {
+      event.preventDefault();
+      if (tempSpeedActive) {
+        clearTempSpeed();
+      } else {
+        // Only toggle play if it wasn't a long press
+        void togglePlay();
+      }
+    }
+  };
+  shortcutUpHandlerRef.current = handlePlayerKeyUp;
+
   useEffect(() => {
     const handlePageKeyDown = (event: KeyboardEvent) => {
       shortcutHandlerRef.current(event);
     };
+    const handlePageKeyUp = (event: KeyboardEvent) => {
+      shortcutUpHandlerRef.current(event);
+    };
     window.addEventListener("keydown", handlePageKeyDown, true);
-    return () => window.removeEventListener("keydown", handlePageKeyDown, true);
+    window.addEventListener("keyup", handlePageKeyUp, true);
+    return () => {
+      window.removeEventListener("keydown", handlePageKeyDown, true);
+      window.removeEventListener("keyup", handlePageKeyUp, true);
+    };
   }, []);
 
   return (
@@ -572,6 +645,9 @@ export function VideoPlayer({
         aria-label={`Lesson video player for ${lessonTitle}`}
         tabIndex={0}
         onPointerDownCapture={handleFramePointerDown}
+        onPointerUpCapture={clearTempSpeed}
+        onPointerCancelCapture={clearTempSpeed}
+        onPointerLeave={clearTempSpeed}
         onMouseMove={scheduleControlsHide}
         onMouseLeave={() =>
           playing && !settingsOpen && setControlsVisible(false)
@@ -609,9 +685,9 @@ export function VideoPlayer({
             event.currentTarget.currentTime =
               Number.isFinite(savedTime) && savedTime > 0
                 ? Math.min(
-                    savedTime,
-                    Math.max(0, event.currentTarget.duration - 1),
-                  )
+                  savedTime,
+                  Math.max(0, event.currentTarget.duration - 1),
+                )
                 : Math.min(0.01, event.currentTarget.duration || 0);
             lastKnownPlaybackTimeRef.current = event.currentTarget.currentTime;
             event.currentTarget.playbackRate = speed;
@@ -663,9 +739,9 @@ export function VideoPlayer({
           </div>
         )}
 
-        {hud && (
+        {(hud || tempSpeedActive) && (
           <div role="status" className="player-hud">
-            {hud}
+            {tempSpeedActive ? "2× ▶▶" : hud}
           </div>
         )}
 

--- a/apps/web/src/VideoPlayer.tsx
+++ b/apps/web/src/VideoPlayer.tsx
@@ -113,6 +113,7 @@ export function VideoPlayer({
   const lastKnownPlaybackTimeRef = useRef(0);
   const shortcutHandlerRef = useRef<(event: KeyboardEvent) => void>(() => { });
   const shortcutUpHandlerRef = useRef<(event: KeyboardEvent) => void>(() => { });
+  const blurHandlerRef = useRef<() => void>(() => { });
   const lastClickTimeRef = useRef(0);
   const wasPausedBeforeSpeedBoostRef = useRef(false);
   const longPressTimerRef = useRef<number | undefined>(undefined);
@@ -317,6 +318,12 @@ export function VideoPlayer({
       setSettingsPage("main");
       return;
     }
+
+    if (
+      event.target instanceof Element &&
+      event.target.closest("[data-player-control], [data-player-menu], input")
+    )
+      return;
 
     const now = Date.now();
     if (now - lastClickTimeRef.current < 400) {
@@ -597,8 +604,19 @@ export function VideoPlayer({
 
   const handlePlayerKeyUp = (event: KeyboardEvent) => {
     if (
+      event.defaultPrevented ||
       event.isComposing ||
       isEditingShortcutTarget(event.target)
+    )
+      return;
+
+    const focusedInteractiveControl =
+      event.target instanceof Element
+        ? event.target.closest(PLAYER_INTERACTIVE_SHORTCUT_SELECTOR)
+        : null;
+    if (
+      focusedInteractiveControl &&
+      focusedInteractiveControl !== frameRef.current
     )
       return;
 
@@ -614,6 +632,8 @@ export function VideoPlayer({
   };
   shortcutUpHandlerRef.current = handlePlayerKeyUp;
 
+  blurHandlerRef.current = clearTempSpeed;
+
   useEffect(() => {
     const handlePageKeyDown = (event: KeyboardEvent) => {
       shortcutHandlerRef.current(event);
@@ -621,11 +641,16 @@ export function VideoPlayer({
     const handlePageKeyUp = (event: KeyboardEvent) => {
       shortcutUpHandlerRef.current(event);
     };
+    const handleBlur = () => {
+      blurHandlerRef.current();
+    };
     window.addEventListener("keydown", handlePageKeyDown, true);
     window.addEventListener("keyup", handlePageKeyUp, true);
+    window.addEventListener("blur", handleBlur);
     return () => {
       window.removeEventListener("keydown", handlePageKeyDown, true);
       window.removeEventListener("keyup", handlePageKeyUp, true);
+      window.removeEventListener("blur", handleBlur);
     };
   }, []);
 
@@ -690,7 +715,7 @@ export function VideoPlayer({
                 )
                 : Math.min(0.01, event.currentTarget.duration || 0);
             lastKnownPlaybackTimeRef.current = event.currentTarget.currentTime;
-            event.currentTarget.playbackRate = speed;
+            event.currentTarget.playbackRate = tempSpeedActive ? 2 : speed;
             event.currentTarget.volume = volume;
           }}
           onLoadedData={paintAmbientFrame}

--- a/apps/web/tests/unit/video-player.test.tsx
+++ b/apps/web/tests/unit/video-player.test.tsx
@@ -107,15 +107,24 @@ describe("video playback consent", () => {
     expect(player).toHaveAttribute("tabindex", "0");
 
     fireEvent.keyDown(player, { key: " ", code: "Space" });
+    fireEvent.keyUp(player, { key: " ", code: "Space" });
     expect(play).toHaveBeenCalledTimes(1);
 
     fireEvent.keyDown(screen.getByRole("button", { name: "Mute" }), {
       key: " ",
       code: "Space",
     });
+    fireEvent.keyUp(screen.getByRole("button", { name: "Mute" }), {
+      key: " ",
+      code: "Space",
+    });
     expect(play).toHaveBeenCalledTimes(1);
 
     fireEvent.keyDown(screen.getByRole("slider", { name: "Volume" }), {
+      key: " ",
+      code: "Space",
+    });
+    fireEvent.keyUp(screen.getByRole("slider", { name: "Volume" }), {
       key: " ",
       code: "Space",
     });


### PR DESCRIPTION
- Implemented a 500ms timeout on pointer down to trigger temporary 2x speed.
- Maintained double-click-and-hold instant 2x speed functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporarily play videos at 2× speed using double-click, long-press, pointer hold, or repeated Space presses.
  * Display a playback-speed indicator while temporary speed mode is active.
  * Automatically restore the previous speed and resume playback when appropriate.
* **Usability Improvements**
  * Improved keyboard and pointer interactions, including reliable release and cleanup behavior.
  * Refined settings dismissal and resume-time formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->