### PR TITLE
feat(web): add explicit lessons dropdown indicator to mobile course h…

### DIFF
--- a/apps/web/src/learning/LearningWorkspace.tsx
+++ b/apps/web/src/learning/LearningWorkspace.tsx
@@ -1007,7 +1007,7 @@ export function LearningWorkspace({
                 <div className="min-w-0">
                   <h1 id="learning-lesson-title" className="truncate">{currentLesson[1]}</h1>
                 </div>
-                <div className="flex items-center gap-1.5 pt-1 text-sm font-semibold text-(--muted) transition-colors group-hover:text-(--text) xl:hidden">
+                <div className="flex items-center gap-1.5 pt-1 text-sm font-semibold text-(--muted) transition-colors group-hover:text-(--text) min-[1081px]:hidden">
                   <span>Lessons</span>
                   <CaretDown size={18} className={`transition-transform duration-200 ${lessonDrawer ? "rotate-180" : ""}`} />
                 </div>

--- a/apps/web/src/learning/LearningWorkspace.tsx
+++ b/apps/web/src/learning/LearningWorkspace.tsx
@@ -28,6 +28,7 @@ import {
   createLessonsById,
   getCourseVideoForLesson,
 } from "./courseContent";
+import { CaretDownIcon as CaretDown } from "@phosphor-icons/react/CaretDown";
 import { Curriculum } from "./Curriculum";
 import { getCourseThumbnail, getCourseTitle } from "./courseMetadata";
 import { Discussion } from "./Discussion";
@@ -998,13 +999,17 @@ export function LearningWorkspace({
                 id="learning-course-content-trigger"
                 ref={lessonTriggerRef}
                 type="button"
-                className="learning-workspace__lesson-heading"
+                className="learning-workspace__lesson-heading group"
                 aria-label={`Open course lessons for ${currentLesson[1]}`}
                 aria-expanded={lessonDrawer}
                 onClick={openLessonDrawer}
               >
                 <div className="min-w-0">
-                  <h1 id="learning-lesson-title">{currentLesson[1]}</h1>
+                  <h1 id="learning-lesson-title" className="truncate">{currentLesson[1]}</h1>
+                </div>
+                <div className="flex items-center gap-1.5 pt-1 text-sm font-semibold text-(--muted) transition-colors group-hover:text-(--text) xl:hidden">
+                  <span>Lessons</span>
+                  <CaretDown size={18} className={`transition-transform duration-200 ${lessonDrawer ? "rotate-180" : ""}`} />
                 </div>
               </button>
             </header>


### PR DESCRIPTION
…eader #45 

- Added a "Lessons ▾" label and dropdown caret next to the lesson title in `LearningWorkspace.tsx`.
- Ensures the curriculum drawer is highly discoverable for mobile users who otherwise might not realize the header is clickable to view the next videos list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the lesson selector with a clear “Lessons” label and responsive layout.
  * Added text truncation for long lesson titles.
  * Added a rotating caret to indicate whether the lesson drawer is open or closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->