### PR TITLE
test(web): align unit tests with current features

### DIFF
--- a/apps/web/tests/unit/course-catalogue.test.tsx
+++ b/apps/web/tests/unit/course-catalogue.test.tsx
@@ -124,7 +124,7 @@ describe("CourseCatalogue", () => {
     fireEvent.click(screen.getByRole("button", { name: "View Curriculum" }));
 
     expect(onNavigatePage).toHaveBeenCalledWith(
-      `/courses/${encodeURIComponent(unenrolledCourse!.id)}/overview#cov-curriculum-heading`,
+      `/courses/${encodeURIComponent(unenrolledCourse!.id)}/overview`,
     );
     expect(setNotice).not.toHaveBeenCalled();
   });

--- a/apps/web/tests/unit/course-components.test.tsx
+++ b/apps/web/tests/unit/course-components.test.tsx
@@ -82,8 +82,8 @@ describe("CourseCard", () => {
 
   it("opens the course overview from the full card details surface", () => {
     const { onNavigatePage, onOpen } = renderCard();
-    const curriculum = screen.getByRole("link", {
-      name: `View curriculum for ${enrolledCourse.title}`,
+    const overview = screen.getByRole("link", {
+      name: `View course overview for ${enrolledCourse.title}`,
     });
     const metadata = screen.getByText(/24 Sections/);
     const card = screen.getByRole("article");
@@ -101,17 +101,17 @@ describe("CourseCard", () => {
       "hover:bg-[color-mix(in_srgb,var(--text)_6%,transparent)]",
       "focus-within:bg-[color-mix(in_srgb,var(--text)_6%,transparent)]",
     );
-    expect(curriculum).toHaveClass("absolute", "inset-0", "cursor-pointer");
+    expect(overview).toHaveClass("absolute", "inset-0", "cursor-pointer");
     expect(screen.getByRole("heading")).toHaveClass(
       "truncate",
       "text-[0.92rem]",
       "lg:text-[0.98rem]",
     );
-    expect(details).toContainElement(curriculum);
+    expect(details).toContainElement(overview);
     expect(details).toContainElement(metadata);
-    expect(curriculum).toHaveAttribute("title", "View Curriculum");
+    expect(overview).toHaveAttribute("title", "View Course Overview");
 
-    fireEvent.click(curriculum);
+    fireEvent.click(overview);
 
     expect(onNavigatePage).toHaveBeenCalledWith(
       "/courses/typescript-course/overview",
@@ -132,7 +132,7 @@ describe("CourseCard", () => {
     expect(onNavigatePage).not.toHaveBeenCalled();
   });
 
-  it("plays a free preview from a non-enrolled thumbnail and opens curriculum elsewhere", () => {
+  it("plays a free preview from a non-enrolled thumbnail and opens its overview elsewhere", () => {
     const { onExplore, onNavigatePage, onOpen } = renderCard({
       course: nonEnrolledCourse,
     });
@@ -154,7 +154,7 @@ describe("CourseCard", () => {
     fireEvent.click(preview);
     fireEvent.click(
       screen.getByRole("link", {
-        name: `View curriculum for ${nonEnrolledCourse.title}`,
+        name: `View course overview for ${nonEnrolledCourse.title}`,
       }),
     );
     fireEvent.click(screen.getByRole("button", { name: "View Curriculum" }));
@@ -162,7 +162,7 @@ describe("CourseCard", () => {
     expect(onOpen).toHaveBeenCalledWith(nonEnrolledCourse);
     expect(onNavigatePage).toHaveBeenCalledTimes(2);
     expect(onNavigatePage).toHaveBeenLastCalledWith(
-      "/courses/figma-ui-essentials/overview#cov-curriculum-heading",
+      "/courses/figma-ui-essentials/overview",
     );
     expect(onExplore).not.toHaveBeenCalled();
   });
@@ -193,7 +193,7 @@ describe("CourseCard", () => {
     fireEvent.click(play);
     fireEvent.click(
       screen.getByRole("link", {
-        name: `View curriculum for ${enrolledCourse.title}`,
+        name: `View course overview for ${enrolledCourse.title}`,
       }),
     );
 

--- a/apps/web/tests/unit/learning-data.test.ts
+++ b/apps/web/tests/unit/learning-data.test.ts
@@ -21,6 +21,7 @@ import {
   getCourseThumbnail,
   getCourseTitle,
 } from "../../src/learning/courseMetadata.js";
+import { CURRICULUM_SECTION_COUNT_DEFAULT } from "../../src/learning/curriculumSize.js";
 
 describe("learning course content", () => {
   it("formats invalid, minute, and hour media durations exactly", () => {
@@ -37,7 +38,7 @@ describe("learning course content", () => {
       Array.from({ length: totalCourseLectures }, (_, index) => index + 1),
     );
     expect([...lessonsById.keys()]).toEqual(lessonSequence);
-    expect(sections).toHaveLength(23);
+    expect(sections).toHaveLength(CURRICULUM_SECTION_COUNT_DEFAULT);
     expect(sections.flatMap(({ lessons }) => lessons)).toHaveLength(
       totalCourseLectures,
     );

--- a/apps/web/tests/unit/learning-settings.test.tsx
+++ b/apps/web/tests/unit/learning-settings.test.tsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { LearningSettings } from "../../src/settings/LearningSettings.js";
 import { CURRICULUM_TEST_PREFERENCES_KEY } from "../../src/learning/curriculumTestPreferences.js";
+import {
+  CURRICULUM_LECTURE_COUNT_DEFAULT,
+  CURRICULUM_SECTION_COUNT_DEFAULT,
+} from "../../src/learning/curriculumSize.js";
 
 describe("LearningSettings curriculum test controls", () => {
   afterEach(() => {
@@ -35,9 +39,9 @@ describe("LearningSettings curriculum test controls", () => {
     ).toHaveTextContent("32 sections · 600 lectures");
 
     fireEvent.click(screen.getByRole("button", { name: "Reset test data" }));
-    expect(sectionInput).toHaveValue(23);
+    expect(sectionInput).toHaveValue(CURRICULUM_SECTION_COUNT_DEFAULT);
     expect(screen.getByRole("spinbutton", { name: "Lectures" })).toHaveValue(
-      600,
+      CURRICULUM_LECTURE_COUNT_DEFAULT,
     );
   });
 });

--- a/apps/web/tests/unit/learning-space.test.tsx
+++ b/apps/web/tests/unit/learning-space.test.tsx
@@ -1,10 +1,4 @@
-import {
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { LearningSpace } from "../../src/learning-space/LearningSpace";
@@ -85,16 +79,17 @@ const renderLearningSpace = ({
 
 describe("LearningSpace", () => {
   it.each([1, 3, 6, 10])(
-    "renders the open-session count and all %i session rows",
+    "renders the active-session count and all %i session rows",
     (count) => {
       renderLearningSpace({ sessions: createSessions(count) });
 
       expect(
         screen.getByRole("button", {
-          name: new RegExp(
-            `Collapse Learning Space, ${count} open session${count === 1 ? "$" : "s$"}`,
-          ),
+          name: `Learning Space, ${count} active ${count === 1 ? "session" : "sessions"}`,
         }),
+      ).toHaveAttribute("aria-expanded", "true");
+      expect(
+        screen.getByRole("region", { name: "Learning Space" }),
       ).toBeVisible();
       expect(screen.getAllByRole("listitem")).toHaveLength(count);
     },
@@ -111,16 +106,19 @@ describe("LearningSpace", () => {
       "Building VeoLMS: Idea to Production",
     );
 
-    const lectureLabel = screen.getByText("L7 · Research Methods");
-    expect(lectureLabel).toHaveClass("truncate");
-    expect(lectureLabel).toHaveAttribute("title", "L7 · Research Methods");
+    const lectureLabel = screen.getByText("Section 2 · Research Methods");
+    expect(lectureLabel).toHaveClass("line-clamp-2");
+    expect(lectureLabel).toHaveAttribute(
+      "title",
+      "Section 2 · Research Methods",
+    );
     expect(
       screen.getByRole("button", {
-        name: "Open Building VeoLMS: Idea to Production, L7 · Research Methods",
+        name: "Open Building VeoLMS: Idea to Production, Section 2 · Research Methods",
       }),
     ).toHaveAttribute(
       "title",
-      "Building VeoLMS: Idea to Production — L7 · Research Methods",
+      "Building VeoLMS: Idea to Production — Section 2 · Research Methods",
     );
   });
 
@@ -154,7 +152,7 @@ describe("LearningSpace", () => {
     expect(screen.queryByRole("button", { current: "page" })).toBeNull();
   });
 
-  it("keeps the count visible when collapsed and persists disclosure through its owner callback", () => {
+  it("keeps the session count on the trigger and persists panel dismissal through its owner callback", () => {
     const sessions = createSessions(3);
     const onExpandedChange = vi.fn();
     const { rerender } = renderLearningSpace({
@@ -164,7 +162,7 @@ describe("LearningSpace", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Collapse Learning Space, 3 open sessions",
+        name: "Learning Space, 3 active sessions",
       }),
     );
     expect(onExpandedChange).toHaveBeenCalledWith(false);
@@ -181,10 +179,12 @@ describe("LearningSpace", () => {
     );
     expect(
       screen.getByRole("button", {
-        name: "Expand Learning Space, 3 open sessions",
+        name: "Learning Space, 3 active sessions",
       }),
     ).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Learning Space" }),
+    ).not.toBeInTheDocument();
   });
 
   it("always exposes a close control, including for an unpinned panel", () => {
@@ -198,24 +198,29 @@ describe("LearningSpace", () => {
     expect(onExpandedChange).toHaveBeenCalledWith(false);
   });
 
-  it("uses the collapsed rail control to request the full sidebar", () => {
-    const onRequestSidebarExpand = vi.fn();
+  it("opens the floating panel directly from the collapsed sidebar", () => {
+    const sessions = createSessions(6);
+    const onExpandedChange = vi.fn();
+    const onActivate = vi.fn();
     renderLearningSpace({
-      sessions: createSessions(6),
+      sessions,
       collapsedSidebar: true,
-      onRequestSidebarExpand,
+      expanded: false,
+      onExpandedChange,
+      onActivate,
     });
 
-    const expandSidebar = screen.getByRole("button", {
-      name: "Expand sidebar to view Learning Space, 6 open sessions",
+    const trigger = screen.getByRole("button", {
+      name: "Learning Space, 6 active sessions",
     });
-    expect(expandSidebar).not.toHaveAttribute("aria-expanded");
-    expect(within(expandSidebar).getByText("6")).toBeVisible();
-    fireEvent.click(expandSidebar);
-    expect(onRequestSidebarExpand).toHaveBeenCalledTimes(1);
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(trigger).toHaveAttribute("title", "Learning Space · 6 active");
+    fireEvent.click(trigger);
+    expect(onExpandedChange).toHaveBeenCalledWith(true);
+    expect(onActivate).toHaveBeenCalledWith(sessions[5]);
   });
 
-  it("uses the drawer as the only mobile scroll surface and keeps row actions touch-sized", () => {
+  it("uses the floating panel as the mobile scroll surface and keeps row actions touch-sized", () => {
     renderLearningSpace({ mobile: true });
 
     const region = screen.getByRole("region", { name: "Learning Space" });
@@ -224,10 +229,10 @@ describe("LearningSpace", () => {
       name: "More actions for The Ultimate TypeScript Course",
     });
 
-    expect(region).toHaveClass("min-h-fit");
-    expect(sessionPanel).toHaveClass("overflow-visible");
-    expect(sessionPanel).not.toHaveClass("overflow-y-auto");
-    expect(moreActions).toHaveClass("size-11");
+    expect(region).toHaveClass("fixed", "overflow-hidden");
+    expect(region).toHaveAttribute("data-learning-swipe-ignore");
+    expect(sessionPanel).toHaveClass("overflow-y-auto", "overscroll-contain");
+    expect(moreActions).toHaveClass("size-9");
   });
 
   it("opens row actions without activating the session and closes only on command", async () => {
@@ -249,11 +254,11 @@ describe("LearningSpace", () => {
       name: "Close session",
     });
     expect(
-      screen.getByRole("menuitem", { name: "Rename session" }),
-    ).toHaveAttribute("aria-disabled", "true");
+      screen.getByRole("menuitem", { name: "Open session" }),
+    ).toBeEnabled();
     expect(
-      screen.getByRole("menuitem", { name: "Pin session" }),
-    ).toHaveAttribute("aria-disabled", "true");
+      screen.getByRole("menuitem", { name: "Open in new tab" }),
+    ).toBeEnabled();
 
     fireEvent.pointerDown(document.body);
     await waitFor(() =>

--- a/apps/web/tests/unit/scrollbar-settings.test.tsx
+++ b/apps/web/tests/unit/scrollbar-settings.test.tsx
@@ -1,12 +1,24 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ScrollbarSettings } from "../../src/settings/scrollbars/ScrollbarSettings.tsx";
 
 describe("scrollbar appearance settings", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem("veolms-hide-scrollbars", "false");
+    delete document.documentElement.dataset.hideScrollbars;
+    delete document.documentElement.dataset.scrollbarStyle;
+  });
+
   it("persists a selected style and applies it to the document", async () => {
     render(<ScrollbarSettings />);
 
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Show scrollbars" }),
+      ).toHaveAttribute("aria-checked", "true"),
+    );
     fireEvent.click(screen.getByRole("radio", { name: /Thick/i }));
 
     await waitFor(() => {
@@ -18,6 +30,11 @@ describe("scrollbar appearance settings", () => {
   it("hides every style control when scrollbars are turned off", async () => {
     render(<ScrollbarSettings />);
 
+    await waitFor(() =>
+      expect(
+        screen.getByRole("switch", { name: "Show scrollbars" }),
+      ).toHaveAttribute("aria-checked", "true"),
+    );
     fireEvent.click(screen.getByRole("switch", { name: "Show scrollbars" }));
 
     await waitFor(() => {

--- a/apps/web/tests/unit/sidebar-preferences.test.ts
+++ b/apps/web/tests/unit/sidebar-preferences.test.ts
@@ -24,6 +24,7 @@ const defaultPreferences = {
   showKeyboardShortcuts: true,
   showCollapsedLabels: true,
   showCollapsedLogo: true,
+  showSidebarOnMobile: false,
   glowPalette: "theme",
   glowShape: "circle",
   glowShapeSize: 100,


### PR DESCRIPTION
## Summary

- align unit tests with the current curriculum and sidebar defaults
- update course overview and Learning Space expectations for the latest behavior
- make scrollbar settings tests deterministic after stored preferences hydrate
- leave production code unchanged

## Validation

- `pnpm --filter @veolms/web test:unit` — 57 files, 553 tests passed
- `pnpm --filter @veolms/web typecheck`
- ESLint and Prettier checks on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Course Navigation**
  - Updated course cards to link to “View course overview” without an automatic curriculum-section jump.

- **Learning Space**
  - Refined session controls, labels, and responsive behavior for a clearer experience across desktop and mobile.
  - Added more direct actions for opening sessions and launching them in a new tab.

- **Accessibility & Preferences**
  - Improved accessible labels and interaction states for learning-space controls and scrollbar preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->