### PR TITLE
feat(api) added end point for mobile app assetlink discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,3 +118,12 @@ FLEET_MANAGER_HEARTBEAT_SECONDS=10
 TRUST_PROXY=false
 # Set to true, proxy IP, or CIDR block behind a trusted reverse proxy/load balancer
 # TRUST_PROXY=true
+
+# ==============================================================================
+# Android App Links (GET /.well-known/assetlinks.json)
+# ==============================================================================
+# Required in production — server boot fails if these are missing (see packages/config).
+# Do not put real production certificate fingerprints here.
+ANDROID_APP_PACKAGE_NAME=
+# Comma-separated SHA-256 certificate fingerprints, e.g. AA:BB:CC:...,11:22:33:...
+ANDROID_APP_SHA256_CERT_FINGERPRINTS=

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,9 @@ import { registerOpenApi } from "./openapi.ts";
 import { createServices, type AppServices } from "./services/index.ts";
 import { config } from "./config.ts";
 import { registerBackgroundJobs } from "./background-jobs.ts";
+import assetLinksPlugin, {
+  ASSET_LINKS_ROUTE,
+} from "./modules/_system/asset-links.plugin.ts";
 
 export const API_ROUTE_PREFIX = "/api/v1";
 
@@ -61,7 +64,10 @@ export async function createApp({
   // registered plugin only apply to that plugin's own routes, not siblings).
 
   app.addHook("preSerialization", async (request, reply, payload) => {
-    if (request.url.startsWith("/api/docs")) {
+    if (
+      request.url.startsWith("/api/docs") ||
+      request.url === ASSET_LINKS_ROUTE
+    ) {
       return payload;
     }
 
@@ -81,6 +87,14 @@ export async function createApp({
       statusCode: reply.statusCode,
       data: payload,
     };
+  });
+
+  // Android App Links: served unprefixed at the literal well-known path Android
+  // expects, so it's registered directly rather than through the /api/v1
+  // autoload below.
+  await app.register(assetLinksPlugin, {
+    packageName: config.ANDROID_APP_PACKAGE_NAME ?? "",
+    fingerprints: config.ANDROID_APP_SHA256_CERT_FINGERPRINTS ?? "",
   });
 
   // Register cookie support for stateful sessions

--- a/apps/api/src/modules/_system/asset-links.plugin.ts
+++ b/apps/api/src/modules/_system/asset-links.plugin.ts
@@ -1,0 +1,69 @@
+import type { FastifyPluginAsync } from "fastify";
+
+/** Fixed by the Android App Links spec — not configurable. */
+export const ASSET_LINKS_ROUTE = "/.well-known/assetlinks.json";
+
+/**
+ * The Digital Asset Links document Android's App Links verifier fetches
+ * from `GET /.well-known/assetlinks.json`. Shape is fixed by Google:
+ * https://developers.google.com/digital-asset-links/v1/getting-started
+ */
+export interface AssetLinksStatement {
+  relation: ["delegate_permission/common.handle_all_urls"];
+  target: {
+    namespace: "android_app";
+    package_name: string;
+    sha256_cert_fingerprints: string[];
+  };
+}
+
+/** Splits the comma-separated fingerprint list and trims each entry. */
+export function parseFingerprints(fingerprints: string): string[] {
+  return fingerprints
+    .split(",")
+    .map((fingerprint) => fingerprint.trim())
+    .filter((fingerprint) => fingerprint.length > 0);
+}
+
+export function buildAssetLinksDocument(
+  packageName: string,
+  fingerprints: string,
+): AssetLinksStatement[] {
+  return [
+    {
+      relation: ["delegate_permission/common.handle_all_urls"],
+      target: {
+        namespace: "android_app",
+        package_name: packageName,
+        sha256_cert_fingerprints: parseFingerprints(fingerprints),
+      },
+    },
+  ];
+}
+
+export interface AssetLinksPluginOptions {
+  packageName: string;
+  fingerprints: string;
+}
+
+/**
+ * Registered directly on the root app (see app.ts) rather than through
+ * `@fastify/autoload`: it must be served at the literal, unprefixed
+ * `/.well-known/assetlinks.json` path Android looks for, not under
+ * `/api/v1`, and its response must be the bare array Google expects, not
+ * the app-wide `{success, data}` envelope — see the matching exemption in
+ * app.ts's `preSerialization` hook.
+ */
+const assetLinksPlugin: FastifyPluginAsync<AssetLinksPluginOptions> = async (
+  app,
+  { packageName, fingerprints },
+) => {
+  const document = buildAssetLinksDocument(packageName, fingerprints);
+
+  app.get(ASSET_LINKS_ROUTE, async (_request, reply) => {
+    reply.type("application/json");
+    return document;
+  });
+};
+
+export default assetLinksPlugin;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -140,6 +140,11 @@ const serverConfigSchema = z.object({
   RAZORPAY_KEY_ID: z.string().optional(),
   RAZORPAY_KEY_SECRET: z.string().optional(),
   RAZORPAY_WEBHOOK_SECRET: z.string().optional(),
+
+  // Android App Links (GET /.well-known/assetlinks.json)
+  ANDROID_APP_PACKAGE_NAME: z.string().optional(),
+  /** Comma-separated list, e.g. "AA:BB:...,11:22:...". Whitespace trimmed per entry. */
+  ANDROID_APP_SHA256_CERT_FINGERPRINTS: z.string().optional(),
 });
 
 const webConfigSchema = z.object({
@@ -179,6 +184,8 @@ const REQUIRED_IN_PRODUCTION: Array<keyof ParsedServerConfig> = [
   "RAZORPAY_KEY_ID",
   "RAZORPAY_KEY_SECRET",
   "RAZORPAY_WEBHOOK_SECRET",
+  "ANDROID_APP_PACKAGE_NAME",
+  "ANDROID_APP_SHA256_CERT_FINGERPRINTS",
 ];
 
 function findMissingRequiredInProduction(parsed: ParsedServerConfig): string[] {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android App Links support through the `/.well-known/assetlinks.json` endpoint.
  * The endpoint now provides Android app package and certificate fingerprint details for link verification.

* **Configuration**
  * Added environment settings for the Android package name and SHA-256 certificate fingerprints.
  * Production deployments must provide both settings to start successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->