### PR TITLE
prevent compact curriculum render loop and speed up unit tests

### DIFF
--- a/apps/web/react-router.config.ts
+++ b/apps/web/react-router.config.ts
@@ -2,6 +2,7 @@ import type { Config } from "@react-router/dev/config";
 import { createLearningPrerenderPaths } from "./src/learning/prerenderLearningPaths";
 
 const staticApplicationPages = [
+  "/",
   "/courses",
   "/settings",
   "/settings/profile",

--- a/apps/web/src/learning/Curriculum.tsx
+++ b/apps/web/src/learning/Curriculum.tsx
@@ -87,17 +87,19 @@ export function Curriculum({
       }),
     );
   const expanded = controlledExpandedSectionIds ?? uncontrolledExpandedSectionIds;
+  const expandedRef = useRef(expanded);
+  expandedRef.current = expanded;
   const setExpanded = useCallback(
     (value: readonly number[] | ((current: readonly number[]) => readonly number[])) => {
       const resolveNext = (current: readonly number[]) =>
         typeof value === "function" ? value(current) : value;
       if (onExpandedSectionIdsChange) {
-        onExpandedSectionIdsChange(resolveNext(expanded));
+        onExpandedSectionIdsChange(resolveNext(expandedRef.current));
         return;
       }
       setUncontrolledExpandedSectionIds((current) => [...resolveNext(current)]);
     },
-    [expanded, onExpandedSectionIdsChange],
+    [onExpandedSectionIdsChange],
   );
   const storageBase = `veolms-learning-${persistenceKey}-curriculum`;
   const [lessonSearch, setLessonSearch] = useSessionStorageState(
@@ -129,6 +131,12 @@ export function Curriculum({
 
   useEffect(() => {
     if (expandAllSections || !hideHero || isExpandedControlled) return;
+    if (
+      expandedRef.current.length === 1 &&
+      expandedRef.current[0] === currentSection.id
+    ) {
+      return;
+    }
     setExpanded([currentSection.id]);
   }, [
     currentSection.id,

--- a/apps/web/src/routing/RouteGuards.tsx
+++ b/apps/web/src/routing/RouteGuards.tsx
@@ -96,6 +96,13 @@ export function AcademyRouteGuard({ children }: { children: ReactNode }) {
     pending,
   ]);
 
+  // Guest-landing aliases immediately redirect into the academy. Keep their
+  // shell visible while the session request settles so static HTML is not
+  // replaced by a loading takeover.
+  if (isGuestLandingPath(path)) {
+    return <>{children}</>;
+  }
+
   if (
     (pending && authenticationRequired) ||
     shouldBlockAcademyRender(path, access)

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     include: ["tests/unit/**/*.test.{ts,tsx}"],
     setupFiles: ["./tests/unit/setup.ts"],
     restoreMocks: true,
+    maxWorkers: "100%",
     testTimeout: 15000,
     hookTimeout: 15000,
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The homepage is now prerendered for faster initial availability and loading.

- **Bug Fixes**
  - Guest landing pages now remain visible while session information is loading.
  - Curriculum sections no longer reset unnecessarily when the selected section is already expanded.
  - Section expansion controls now consistently reflect the latest expanded state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->