### PR TITLE
feat(webview): add WebView-to-native bridge

### DIFF
--- a/packages/webview-bridge/AGENTS.md
+++ b/packages/webview-bridge/AGENTS.md
@@ -1,0 +1,130 @@
+# `@veolms/webview-bridge` Agent Instructions
+
+These instructions apply to `packages/webview-bridge`. Task-specific user instructions take precedence.
+
+## Package boundary
+
+`@veolms/webview-bridge` is the **JavaScript/TypeScript core client** for VeoLMS WebView-to-native communication.
+
+- Zero runtime dependencies.
+- No React, UI, framework, or application-domain dependencies.
+- Android/iOS implementations are outside this package.
+- `src/index.ts` is the public entry point.
+- `package.json` is currently private to the workspace.
+- The package is consumed by web applications and does not require a separate manual build step for normal consumption.
+
+## Architecture
+
+Preserve this separation:
+
+```text
+Application contract
+        ↓
+NativeBridge / Proxy
+        ↓
+NativeTransport
+        ↓
+NativeEndpoint
+        ↓
+Android / iOS WebView
+```
+
+### `endpoint/`
+
+Only normalize platform WebView messaging into `NativeEndpoint` (`postMessage`, `onMessage`, `dispose`). Do not put protocol, metadata, request correlation, or application APIs here.
+
+Current adapters:
+
+- Android Modern WebMessage listener
+- Android Legacy `addJavascriptInterface`
+- iOS WebKit message handler with reply
+
+### `protocol/`
+
+Own wire-level types, constants, JSON encoding/decoding, and structural validation. Current protocol version is `1`.
+
+### `transport/`
+
+Own request IDs, Promise correlation, initialization, session state, timeouts, replies, events, and bridge errors.
+
+### `bridge/`
+
+Own runtime capability metadata, the dynamic Proxy, sessions, caching, and `buildNativeBridge()`.
+
+The Proxy must stay generic. Do not implement individual methods such as `showToast()` or `hideStatusBar()` inside it.
+
+## Contract generation
+
+The native bridge library generates the TypeScript contract definitions used by the web application.
+
+- Do not manually recreate the native API contract in the web app when generated contracts are available.
+- Native API changes should update the generated contract definitions as part of the native library workflow.
+- Treat the generated contract as the shared API surface between native and web code.
+- Do not make JS bridge implementation changes just to add individual native methods unless the generic bridge itself needs new capabilities.
+
+## Non-negotiable invariants
+
+1. **Platform transparency:** consumers should not need Android/iOS-specific WebView checks for normal bridge usage.
+2. **Contract vs metadata:** TypeScript contracts provide compile-time types; native metadata determines runtime capability availability.
+3. **Async API:** native capabilities are exposed through Promises regardless of whether native implementation is internally synchronous or asynchronous.
+4. **Path mapping:** `bridge.systemBars.hideStatusBar()` maps to `systemBars:hideStatusBar` on the wire.
+5. **Request IDs:** every request needs a unique correlation ID.
+6. **Initialization:** `buildNativeBridge()` performs the handshake before returning the bridge.
+7. **Unsupported functions:** missing function capabilities resolve as NOOPs rather than being blindly sent to native.
+8. **Promise safety:** proxy access to `then` must remain `undefined`.
+9. **`null` vs `void`:** explicit `null` stays `null`; `ACK` for `void` resolves to `undefined`.
+10. **Cleanup:** disposal must remove endpoint listeners and generated callback handlers.
+11. **No application policy:** authentication, authorization, persistence, analytics, and product-specific capabilities belong elsewhere.
+12. **Normal usage:** `buildNativeBridge()` should normally be initialized once per application. Internal caching and initialization deduplication make repeated calls safe, but application code should still avoid unnecessary calls.
+
+## Native compatibility
+
+Treat the JavaScript protocol as a shared contract with separate Android and iOS implementations. Before changing wire behavior, check:
+
+- `init`, `invoke`, `get`, `set` envelopes;
+- capability metadata;
+- session IDs and request IDs;
+- `success`, `ack`, and `error` semantics;
+- native events;
+- Android Modern/Legacy behavior;
+- iOS reply behavior.
+
+Do not make a protocol change on the JS side alone and assume native remains compatible.
+
+## Dependencies and scope
+
+Do not add runtime dependencies without explicit architectural justification. Keep this package focused on the generic JavaScript/TypeScript bridge implementation and avoid framework, UI, or platform-specific dependencies.
+
+The current codec intentionally uses manual structural validation to preserve the zero-dependency boundary. Future work such as schema libraries, cancellation, or binary transfer requires an explicit design decision. Contract generation is not included in this list because it is already part of the native bridge library workflow.
+
+## Security and robustness
+
+- Validate/handle native messages at the protocol boundary.
+- Do not log credentials, tokens, or sensitive native payloads by default.
+- Do not weaken endpoint detection or platform assumptions just to make tests pass.
+- Remember Android Legacy `addJavascriptInterface` can execute synchronously; JS code must not assume it behaves like an asynchronous channel.
+- The current wire protocol is JSON/text based; do not introduce binary transport assumptions without protocol design.
+
+## Development
+
+This package is consumed by web applications through the workspace and does not require a separate manual build step for normal consumption.
+
+Current package validation:
+
+```bash
+pnpm --filter @veolms/webview-bridge typecheck
+```
+
+After changes:
+
+1. Run the narrowest relevant typecheck.
+2. Review protocol and endpoint diffs carefully.
+3. For protocol changes, verify request/reply and event flows.
+4. For endpoint changes, verify disposal and re-initialization/navigation behavior.
+5. Separate pre-existing failures from failures introduced by the change.
+
+## Documentation
+
+Keep package documentation concise and accurate. README covers consumer usage and scope; this file covers agent/maintainer constraints. Detailed protocol rationale belongs in the dedicated bridge architecture/specification documents.
+
+Never describe planned/future functionality as implemented functionality.

--- a/packages/webview-bridge/README.md
+++ b/packages/webview-bridge/README.md
@@ -1,0 +1,127 @@
+# `@veolms/webview-bridge`
+
+Zero-dependency TypeScript client for communicating with native capabilities exposed by Android/iOS WebViews through one platform-independent API.
+
+This package is the **JavaScript side only**. Android and iOS native implementations live outside this package and must expose a WebView endpoint that follows the bridge protocol.
+
+## What it does
+
+- Detects supported native WebView endpoints automatically.
+- Supports Android Modern, Android Legacy, and iOS WKWebView.
+- Builds a typed developer-facing bridge from generated TypeScript contracts.
+- Discovers runtime capabilities through an initialization handshake.
+- Correlates async native replies using request IDs.
+- Supports native events, timeouts, structured errors, and writable/readable properties.
+- Maps nested JS APIs to colon-separated protocol paths.
+- Gracefully NOOPs unsupported function capabilities.
+- Has no React, UI, framework, or runtime npm dependencies.
+
+## Usage
+
+The native library generates the TypeScript bridge contracts. The web app consumes the generated `NativeBridgeContract` type rather than defining the native API surface manually.
+
+```ts
+import { buildNativeBridge } from "@veolms/webview-bridge";
+import type { NativeBridgeContract } from "./native-bridge-contracts";
+
+const bridge = await buildNativeBridge<NativeBridgeContract>();
+
+if (bridge) {
+  await bridge.platform();
+  await bridge.showToast("Hello");
+  await bridge.systemBars.hideStatusBar();
+}
+```
+
+`buildNativeBridge()` returns `null` when no supported native endpoint exists, allowing the same application code to run outside a native WebView.
+
+The generic contract is compile-time only. The runtime bridge is a dynamic `Proxy` backed by native capability metadata.
+
+`buildNativeBridge()` should normally be called once for the application. The library caches initialized sessions and deduplicates concurrent initialization, so repeated calls are handled safely, but application code should still avoid unnecessary calls.
+
+In a React application, a small application-level hook can manage the bridge state and loading lifecycle when convenient. That hook does not belong in this core package.
+
+## Native integration
+
+The native application exposes a small message endpoint, normally named `NativeBridge`:
+
+```text
+Native WebView API
+      ↓
+NativeEndpoint
+      ↓
+NativeTransport
+      ↓
+NativeBridge Proxy
+      ↓
+Application code
+```
+
+Supported mechanisms:
+
+- Android Modern: `addWebMessageListener`
+- Android Legacy: `addJavascriptInterface` with the standardized `postMessage` channel
+- iOS: `WKScriptMessageHandlerWithReply`
+
+Native code owns the actual capabilities and must implement the protocol's initialization, invocation/property handling, errors, events, and session behavior.
+
+## Protocol
+
+The wire format is JSON strings. Requests use `init`, `invoke`, `get`, or `set`; replies are correlated by `id`; native can also send events.
+
+```json
+{
+  "type": "request",
+  "operation": "invoke",
+  "id": "...",
+  "payload": {
+    "path": "showToast",
+    "args": ["Hello"],
+    "sessionId": "..."
+  }
+}
+```
+
+Current protocol version: **1**.
+
+`ACK` represents a `void` operation and resolves to `undefined`; a successful value return, including explicit `null`, uses `success`.
+
+## Public API
+
+The root export currently provides:
+
+- `buildNativeBridge`
+- `clearNativeBridgeCache`
+- `BuildBridgeOptions`
+- bridge error classes
+- protocol, metadata, endpoint, and transport types
+
+`buildNativeBridge()` is the normal application-facing API. `BuildBridgeOptions` exists for cases where the defaults need to be adjusted, but the defaults are intended to be sufficient for normal use. `clearNativeBridgeCache()` is a lifecycle utility and is not normally needed by application code.
+
+## Source layout
+
+```text
+src/
+├── endpoint/    WebView platform adapters + discovery
+├── protocol/    Wire types, constants, codec, validation
+├── transport/   Requests, replies, events, timeouts, errors
+├── bridge/      Metadata, Proxy, sessions, factory
+└── index.ts     Public exports
+```
+
+Keep these boundaries intact. The proxy must remain generic and must not contain individual native APIs.
+
+## Development
+
+This package is consumed by web applications through the workspace package. It does not require a separate manual build step for normal consumption.
+
+For package-level validation from the monorepo root:
+
+```bash
+pnpm --filter @veolms/webview-bridge typecheck
+```
+
+## Scope
+
+This package provides the JavaScript/TypeScript side of the WebView-to-native bridge. Native Android/iOS implementations are separate from this package. 
+

--- a/packages/webview-bridge/README.md
+++ b/packages/webview-bridge/README.md
@@ -123,5 +123,4 @@ pnpm --filter @veolms/webview-bridge typecheck
 
 ## Scope
 
-This package provides the JavaScript/TypeScript side of the WebView-to-native bridge. Native Android/iOS implementations are separate from this package. 
-
+This package provides the JavaScript/TypeScript side of the WebView-to-native bridge. Native Android/iOS implementations are separate from this package.

--- a/packages/webview-bridge/package.json
+++ b/packages/webview-bridge/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@veolms/webview-bridge",
+  "private": true,
+  "type": "module",
+  "exports": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/webview-bridge/src/bridge/build-native-bridge.ts
+++ b/packages/webview-bridge/src/bridge/build-native-bridge.ts
@@ -1,0 +1,151 @@
+import { DEFAULT_BRIDGE_NAME } from "../protocol/constants.ts";
+import { createNativeEndpoint } from "../endpoint/native-endpoint.ts";
+import { DefaultNativeTransport } from "../transport/native-transport.ts";
+import { MetadataRegistry } from "./metadata.ts";
+import { NativeBridgeSession } from "./native-bridge.ts";
+
+/**
+ * Configuration options for buildNativeBridge().
+ */
+export interface BuildBridgeOptions {
+  /**
+   * Enable verbose internal debug logging to browser console.
+   */
+  debug?: boolean;
+  /**
+   * Default timeout in milliseconds for native requests (0 or undefined disables timeout).
+   */
+  timeoutMs?: number;
+  /**
+   * Optional callback invoked with detailed diagnostic error if bridge initialization fails.
+   */
+  onInitError?: (error: Error) => void;
+}
+
+/**
+ * Cache for active bridge sessions keyed by endpoint registration name.
+ */
+const bridgeCache = new Map<string, NativeBridgeSession>();
+
+/**
+ * Map tracking in-flight initialization promises to prevent duplicate concurrent initialization requests.
+ */
+const initPromises = new Map<string, Promise<NativeBridgeSession>>();
+
+/**
+ * Constructs or retrieves a cached NativeBridge instance matching frontend contract `T`.
+ *
+ * Handles endpoint discovery, initialization handshake, capability metadata caching,
+ * and concurrent request deduplication.
+ *
+ * @param endpointName Registration name of the native endpoint (default: "NativeBridge")
+ * @param options Build & debug options
+ * @returns Promise resolving to typed proxy `T`, or `null` if native endpoint is unavailable.
+ */
+export async function buildNativeBridge<
+  T extends object = Record<string, unknown>,
+>(
+  endpointName: string = DEFAULT_BRIDGE_NAME,
+  options?: BuildBridgeOptions,
+): Promise<T | null> {
+  const name =
+    (typeof endpointName === "string" ? endpointName : "").trim() ||
+    DEFAULT_BRIDGE_NAME;
+
+  if (options?.debug) {
+    console.log(`[NativeBridge Debug] buildNativeBridge("${name}") requested.`);
+  }
+
+  // 1. Return existing active bridge instance if cached
+  const existingSession = bridgeCache.get(name);
+  if (existingSession) {
+    if (options?.debug) {
+      console.log(
+        `[NativeBridge Debug] Returning cached session for "${name}".`,
+      );
+    }
+    return existingSession.getProxy<T>();
+  }
+
+  // 2. Reuse in-flight initialization promise if concurrent initialization is currently running
+  const inFlightPromise = initPromises.get(name);
+  if (inFlightPromise) {
+    try {
+      const session = await inFlightPromise;
+      return session.getProxy<T>();
+    } catch {
+      return null;
+    }
+  }
+
+  // 3. Initiate new bridge session
+  const initTask = (async (): Promise<NativeBridgeSession> => {
+    const endpoint = createNativeEndpoint(name);
+    if (!endpoint) {
+      const err = new Error(
+        `No native endpoint object found on window for "${name}".`,
+      );
+      if (options?.onInitError) {
+        options.onInitError(err);
+      }
+      throw err;
+    }
+
+    if (options?.debug) {
+      console.log(
+        `[NativeBridge Debug] Discovered endpoint "${name}" on platform: ${endpoint.platform}`,
+      );
+    }
+
+    const transport = new DefaultNativeTransport(endpoint, {
+      defaultTimeoutMs: options?.timeoutMs,
+    });
+
+    try {
+      const metadataPayload = await transport.initialize();
+      const metadataRegistry = new MetadataRegistry(metadataPayload);
+
+      const session = new NativeBridgeSession(
+        name,
+        transport,
+        metadataRegistry,
+      );
+      bridgeCache.set(name, session);
+      return session;
+    } catch (err) {
+      if (options?.onInitError && err instanceof Error) {
+        options.onInitError(err);
+      }
+      throw err;
+    }
+  })();
+
+  initPromises.set(name, initTask);
+
+  try {
+    const session = await initTask;
+    return session.getProxy<T>();
+  } catch (error) {
+    if (options?.debug) {
+      console.warn(
+        `[NativeBridge Debug] buildNativeBridge("${name}") failed to initialize:`,
+        error,
+      );
+    }
+    return null;
+  } finally {
+    initPromises.delete(name);
+  }
+}
+
+/**
+ * Clears cached bridge sessions and disposes underlying transports.
+ * Primarily useful for testing or WebView re-navigation teardown.
+ */
+export function clearNativeBridgeCache(): void {
+  for (const session of bridgeCache.values()) {
+    session.dispose();
+  }
+  bridgeCache.clear();
+  initPromises.clear();
+}

--- a/packages/webview-bridge/src/bridge/build-native-bridge.ts
+++ b/packages/webview-bridge/src/bridge/build-native-bridge.ts
@@ -38,13 +38,19 @@ const initPromises = new Map<string, Promise<NativeBridgeSession>>();
 let cacheGeneration = 0;
 
 /**
- * Evicts a session from the active session cache by endpoint name.
+ * Evicts a session from the active session cache by endpoint name if it matches the current owner.
  */
-export function evictBridgeSession(endpointName: string): void {
+export function evictBridgeSession(
+  endpointName: string,
+  sessionToEvict?: NativeBridgeSession,
+): void {
   const name =
     (typeof endpointName === "string" ? endpointName : "").trim() ||
     DEFAULT_BRIDGE_NAME;
-  bridgeCache.delete(name);
+  const current = bridgeCache.get(name);
+  if (!sessionToEvict || current === sessionToEvict) {
+    bridgeCache.delete(name);
+  }
 }
 
 /**
@@ -121,20 +127,20 @@ export async function buildNativeBridge<
 
     try {
       const metadataPayload = await transport.initialize();
-      const metadataRegistry = new MetadataRegistry(metadataPayload);
 
+      if (currentGeneration !== cacheGeneration) {
+        transport.dispose();
+        throw new Error(
+          `Bridge cache was cleared while endpoint "${name}" was initializing.`,
+        );
+      }
+
+      const metadataRegistry = new MetadataRegistry(metadataPayload);
       const session = new NativeBridgeSession(
         name,
         transport,
         metadataRegistry,
       );
-
-      if (currentGeneration !== cacheGeneration) {
-        session.dispose();
-        throw new Error(
-          `Bridge cache was cleared while endpoint "${name}" was initializing.`,
-        );
-      }
 
       bridgeCache.set(name, session);
       return session;
@@ -160,7 +166,9 @@ export async function buildNativeBridge<
     }
     return null;
   } finally {
-    initPromises.delete(name);
+    if (initPromises.get(name) === initTask) {
+      initPromises.delete(name);
+    }
   }
 }
 

--- a/packages/webview-bridge/src/bridge/build-native-bridge.ts
+++ b/packages/webview-bridge/src/bridge/build-native-bridge.ts
@@ -33,6 +33,21 @@ const bridgeCache = new Map<string, NativeBridgeSession>();
 const initPromises = new Map<string, Promise<NativeBridgeSession>>();
 
 /**
+ * Generation counter for invalidating in-flight initialization tasks when clearNativeBridgeCache is called.
+ */
+let cacheGeneration = 0;
+
+/**
+ * Evicts a session from the active session cache by endpoint name.
+ */
+export function evictBridgeSession(endpointName: string): void {
+  const name =
+    (typeof endpointName === "string" ? endpointName : "").trim() ||
+    DEFAULT_BRIDGE_NAME;
+  bridgeCache.delete(name);
+}
+
+/**
  * Constructs or retrieves a cached NativeBridge instance matching frontend contract `T`.
  *
  * Handles endpoint discovery, initialization handshake, capability metadata caching,
@@ -78,6 +93,9 @@ export async function buildNativeBridge<
     }
   }
 
+  // Capture current cache generation to detect cache clearing during init
+  const currentGeneration = cacheGeneration;
+
   // 3. Initiate new bridge session
   const initTask = (async (): Promise<NativeBridgeSession> => {
     const endpoint = createNativeEndpoint(name);
@@ -110,6 +128,14 @@ export async function buildNativeBridge<
         transport,
         metadataRegistry,
       );
+
+      if (currentGeneration !== cacheGeneration) {
+        session.dispose();
+        throw new Error(
+          `Bridge cache was cleared while endpoint "${name}" was initializing.`,
+        );
+      }
+
       bridgeCache.set(name, session);
       return session;
     } catch (err) {
@@ -143,6 +169,7 @@ export async function buildNativeBridge<
  * Primarily useful for testing or WebView re-navigation teardown.
  */
 export function clearNativeBridgeCache(): void {
+  cacheGeneration++;
   for (const session of bridgeCache.values()) {
     session.dispose();
   }

--- a/packages/webview-bridge/src/bridge/metadata.ts
+++ b/packages/webview-bridge/src/bridge/metadata.ts
@@ -1,0 +1,70 @@
+import type { BridgeCapability, BridgeMetadataPayload } from "./types.d.ts";
+import { PATH_SEPARATOR } from "../protocol/constants.ts";
+
+/**
+ * Registry maintaining runtime native capability metadata.
+ */
+export class MetadataRegistry {
+  public readonly protocolVersion: number;
+  public readonly bridgeVersion: string;
+  public readonly sessionId: string;
+  public readonly rawPayload: BridgeMetadataPayload;
+  private readonly capabilitiesByPath = new Map<string, BridgeCapability>();
+  private readonly knownNamespaces = new Set<string>();
+
+  constructor(payload: BridgeMetadataPayload) {
+    this.rawPayload = payload;
+    this.protocolVersion = payload.protocolVersion;
+    this.bridgeVersion = payload.bridgeVersion;
+    this.sessionId = payload.sessionId;
+
+    for (const capPayload of payload.capabilities) {
+      const capability: BridgeCapability = {
+        path: capPayload.path,
+        kind: capPayload.kind,
+        readable: capPayload.readable ?? true,
+        writable: capPayload.writable ?? false,
+      };
+      this.capabilitiesByPath.set(capPayload.path, capability);
+
+      // Index prefix namespaces (e.g. "systemBars:hideStatusBar" -> namespace "systemBars")
+      const segments = capPayload.path.split(PATH_SEPARATOR);
+      for (let i = 1; i < segments.length; i++) {
+        const nsPath = segments.slice(0, i).join(PATH_SEPARATOR);
+        this.knownNamespaces.add(nsPath);
+      }
+    }
+  }
+
+  public hasCapability(path: string): boolean {
+    return this.capabilitiesByPath.has(path);
+  }
+
+  public getCapability(path: string): BridgeCapability | undefined {
+    return this.capabilitiesByPath.get(path);
+  }
+
+  public isNamespace(path: string): boolean {
+    return this.knownNamespaces.has(path);
+  }
+
+  public isFunction(path: string): boolean {
+    const cap = this.capabilitiesByPath.get(path);
+    return cap?.kind === "function";
+  }
+
+  public isProperty(path: string): boolean {
+    const cap = this.capabilitiesByPath.get(path);
+    return cap?.kind === "property";
+  }
+
+  public isReadable(path: string): boolean {
+    const cap = this.capabilitiesByPath.get(path);
+    return cap?.readable ?? false;
+  }
+
+  public isWritable(path: string): boolean {
+    const cap = this.capabilitiesByPath.get(path);
+    return cap?.writable ?? false;
+  }
+}

--- a/packages/webview-bridge/src/bridge/native-bridge.ts
+++ b/packages/webview-bridge/src/bridge/native-bridge.ts
@@ -48,11 +48,11 @@ export class NativeBridgeSession {
   }
 
   /**
-   * Dispose bridge session, remove from session cache, and clean up underlying transport.
+   * Dispose bridge session, remove from session cache if current owner, and clean up underlying transport.
    */
   public dispose(): void {
     this.rootProxy = null;
-    evictBridgeSession(this.endpointName);
+    evictBridgeSession(this.endpointName, this);
     this.transport.dispose();
   }
 }

--- a/packages/webview-bridge/src/bridge/native-bridge.ts
+++ b/packages/webview-bridge/src/bridge/native-bridge.ts
@@ -1,0 +1,51 @@
+import type {
+  BridgeEventHandler,
+  NativeTransport,
+} from "../transport/types.d.ts";
+import type { MetadataRegistry } from "./metadata.ts";
+import { createBridgeProxy } from "./proxy.ts";
+
+/**
+ * Concrete session container for initialized NativeBridge instances.
+ */
+export class NativeBridgeSession {
+  public readonly endpointName: string;
+  public readonly transport: NativeTransport;
+  public readonly metadata: MetadataRegistry;
+  private rootProxy: unknown = null;
+
+  constructor(
+    endpointName: string,
+    transport: NativeTransport,
+    metadata: MetadataRegistry,
+  ) {
+    this.endpointName = endpointName;
+    this.transport = transport;
+    this.metadata = metadata;
+  }
+
+  /**
+   * Returns a cached typed Proxy object matching frontend contract T.
+   */
+  public getProxy<T extends object>(): T {
+    if (!this.rootProxy) {
+      this.rootProxy = createBridgeProxy<T>(this.transport, this.metadata);
+    }
+    return this.rootProxy as T;
+  }
+
+  /**
+   * Subscribe to native events directly via session.
+   */
+  public onEvent(eventName: string, handler: BridgeEventHandler): () => void {
+    return this.transport.onEvent(eventName, handler);
+  }
+
+  /**
+   * Dispose bridge session and clean up underlying transport.
+   */
+  public dispose(): void {
+    this.rootProxy = null;
+    this.transport.dispose();
+  }
+}

--- a/packages/webview-bridge/src/bridge/native-bridge.ts
+++ b/packages/webview-bridge/src/bridge/native-bridge.ts
@@ -4,6 +4,7 @@ import type {
 } from "../transport/types.d.ts";
 import type { MetadataRegistry } from "./metadata.ts";
 import { createBridgeProxy } from "./proxy.ts";
+import { evictBridgeSession } from "./build-native-bridge.ts";
 
 /**
  * Concrete session container for initialized NativeBridge instances.
@@ -29,7 +30,12 @@ export class NativeBridgeSession {
    */
   public getProxy<T extends object>(): T {
     if (!this.rootProxy) {
-      this.rootProxy = createBridgeProxy<T>(this.transport, this.metadata);
+      this.rootProxy = createBridgeProxy<T>(
+        this.transport,
+        this.metadata,
+        "",
+        this,
+      );
     }
     return this.rootProxy as T;
   }
@@ -42,10 +48,11 @@ export class NativeBridgeSession {
   }
 
   /**
-   * Dispose bridge session and clean up underlying transport.
+   * Dispose bridge session, remove from session cache, and clean up underlying transport.
    */
   public dispose(): void {
     this.rootProxy = null;
+    evictBridgeSession(this.endpointName);
     this.transport.dispose();
   }
 }

--- a/packages/webview-bridge/src/bridge/proxy.ts
+++ b/packages/webview-bridge/src/bridge/proxy.ts
@@ -6,6 +6,7 @@ import type {
   NativeTransport,
 } from "../transport/types.d.ts";
 import type { MetadataRegistry } from "./metadata.ts";
+import type { NativeBridgeSession } from "./native-bridge.ts";
 
 /**
  * Creates a developer-facing Proxy object for NativeBridge.
@@ -18,6 +19,7 @@ export function createBridgeProxy<T extends object>(
   transport: NativeTransport,
   metadata: MetadataRegistry,
   basePath: string = "",
+  session?: NativeBridgeSession,
 ): T {
   // Empty dummy target for Proxy wrapping
   const NativeBridgeProxyTarget = function () {} as unknown as object;
@@ -54,7 +56,7 @@ export function createBridgeProxy<T extends object>(
             transport.onEvent(eventName, handler);
         }
         if (prop === "dispose") {
-          return () => transport.dispose();
+          return () => (session ? session.dispose() : transport.dispose());
         }
       }
 
@@ -89,6 +91,8 @@ export function createBridgeProxy<T extends object>(
         if (metadata.isReadable(currentPath)) {
           return transport.get(currentPath);
         }
+        // Write-only property returns undefined when read directly
+        return undefined;
       }
 
       // 6. Support function calls directly on the property
@@ -117,8 +121,8 @@ export function createBridgeProxy<T extends object>(
           );
         }
         const bridgeValue = value === undefined ? null : (value as BridgeValue);
-        // Execute set call asynchronously
-        void transport.set(currentPath, bridgeValue);
+        // Execute set call asynchronously and swallow rejections to avoid unhandledrejection events in browser
+        void transport.set(currentPath, bridgeValue).catch(() => {});
         return true;
       }
 
@@ -136,7 +140,9 @@ export function createBridgeProxy<T extends object>(
       );
 
       if (metadata.hasCapability(basePath)) {
-        return transport.invoke(basePath, bridgeArgs);
+        if (metadata.isFunction(basePath)) {
+          return transport.invoke(basePath, bridgeArgs);
+        }
       }
       // NOOP
       return Promise.resolve(null);
@@ -170,6 +176,7 @@ function createBridgeProxyInternal<T extends object>(
         if (metadata.isReadable(childPath)) {
           return transport.get(childPath);
         }
+        return undefined;
       }
 
       const childFunctionHandler = (
@@ -178,7 +185,10 @@ function createBridgeProxyInternal<T extends object>(
         const bridgeArgs: BridgeValue[] = args.map((arg) =>
           arg === undefined ? null : (arg as BridgeValue),
         );
-        if (metadata.hasCapability(childPath)) {
+        if (
+          metadata.hasCapability(childPath) &&
+          metadata.isFunction(childPath)
+        ) {
           return transport.invoke(childPath, bridgeArgs);
         }
         return Promise.resolve(null);
@@ -204,7 +214,7 @@ function createBridgeProxyInternal<T extends object>(
           );
         }
         const bridgeValue = value === undefined ? null : (value as BridgeValue);
-        void transport.set(childPath, bridgeValue);
+        void transport.set(childPath, bridgeValue).catch(() => {});
         return true;
       }
       return true;

--- a/packages/webview-bridge/src/bridge/proxy.ts
+++ b/packages/webview-bridge/src/bridge/proxy.ts
@@ -1,0 +1,217 @@
+import { PATH_SEPARATOR } from "../protocol/constants.ts";
+import type { BridgeValue } from "../protocol/types.d.ts";
+import { BridgeUnsupportedError } from "../transport/errors.ts";
+import type {
+  BridgeEventHandler,
+  NativeTransport,
+} from "../transport/types.d.ts";
+import type { MetadataRegistry } from "./metadata.ts";
+
+/**
+ * Creates a developer-facing Proxy object for NativeBridge.
+ * Translates JavaScript property paths (e.g. `bridge.systemBars.hideStatusBar()`)
+ * into protocol paths (`systemBars:hideStatusBar`).
+ * Enforces NOOP semantics for contract members missing in runtime metadata.
+ * Safely handles `then`, symbols, and inspection methods.
+ */
+export function createBridgeProxy<T extends object>(
+  transport: NativeTransport,
+  metadata: MetadataRegistry,
+  basePath: string = "",
+): T {
+  // Empty dummy target for Proxy wrapping
+  const NativeBridgeProxyTarget = function () {} as unknown as object;
+
+  const proxy = new Proxy(NativeBridgeProxyTarget, {
+    get(_target, prop) {
+      // 1. Prevent Proxy from acting like a Promise when awaited
+      if (prop === "then") {
+        return undefined;
+      }
+
+      // 2. Handle JS Symbols gracefully
+      if (typeof prop === "symbol") {
+        if (prop === Symbol.toStringTag) {
+          return `NativeBridge(${transport.endpointName})`;
+        }
+        return undefined;
+      }
+
+      // 3. Handle inspection and utility methods on root bridge proxy
+      if (basePath === "") {
+        if (prop === "toString") {
+          return () => `[NativeBridge ${transport.endpointName}]`;
+        }
+        if (prop === "toJSON") {
+          return () => ({
+            endpoint: transport.endpointName,
+            sessionId: transport.sessionId,
+            protocolVersion: metadata.protocolVersion,
+          });
+        }
+        if (prop === "onEvent") {
+          return (eventName: string, handler: BridgeEventHandler) =>
+            transport.onEvent(eventName, handler);
+        }
+        if (prop === "dispose") {
+          return () => transport.dispose();
+        }
+      }
+
+      // Build colon-separated protocol path
+      const currentPath =
+        basePath === ""
+          ? String(prop)
+          : `${basePath}${PATH_SEPARATOR}${String(prop)}`;
+
+      // 4. Return an invokable function handler for method calls
+      const functionHandler = (
+        ...args: unknown[]
+      ): Promise<BridgeValue | null> => {
+        // Sanitize arguments to JSON-safe BridgeValue array
+        const bridgeArgs: BridgeValue[] = args.map((arg) =>
+          arg === undefined ? null : (arg as BridgeValue),
+        );
+
+        if (metadata.hasCapability(currentPath)) {
+          if (metadata.isFunction(currentPath)) {
+            return transport.invoke(currentPath, bridgeArgs);
+          }
+        }
+
+        // NOOP Semantics: If member is in frontend contract but unsupported in native metadata,
+        // resolve cleanly according to contract Promise return shape.
+        return Promise.resolve(null);
+      };
+
+      // 5. If metadata explicitly marks this path as a Property, read property value
+      if (metadata.isProperty(currentPath)) {
+        if (metadata.isReadable(currentPath)) {
+          return transport.get(currentPath);
+        }
+      }
+
+      // 6. Support function calls directly on the property
+      return createBridgeProxyInternal(
+        transport,
+        metadata,
+        currentPath,
+        functionHandler,
+      );
+    },
+
+    set(_target, prop, value) {
+      if (typeof prop === "symbol" || prop === "then") {
+        return false;
+      }
+
+      const currentPath =
+        basePath === ""
+          ? String(prop)
+          : `${basePath}${PATH_SEPARATOR}${String(prop)}`;
+
+      if (metadata.hasCapability(currentPath)) {
+        if (!metadata.isWritable(currentPath)) {
+          throw new BridgeUnsupportedError(
+            `Property "${currentPath}" is read-only on native.`,
+          );
+        }
+        const bridgeValue = value === undefined ? null : (value as BridgeValue);
+        // Execute set call asynchronously
+        void transport.set(currentPath, bridgeValue);
+        return true;
+      }
+
+      // NOOP for unsupported property setters
+      return true;
+    },
+
+    apply(_target, _thisArg, argArray) {
+      // Handles function invocation when proxy itself is invoked
+      if (basePath === "") {
+        return undefined;
+      }
+      const bridgeArgs: BridgeValue[] = argArray.map((arg) =>
+        arg === undefined ? null : (arg as BridgeValue),
+      );
+
+      if (metadata.hasCapability(basePath)) {
+        return transport.invoke(basePath, bridgeArgs);
+      }
+      // NOOP
+      return Promise.resolve(null);
+    },
+  });
+
+  return proxy as unknown as T;
+}
+
+/**
+ * Internal nested proxy creation helper connecting function invocation & path traversal.
+ */
+function createBridgeProxyInternal<T extends object>(
+  transport: NativeTransport,
+  metadata: MetadataRegistry,
+  currentPath: string,
+  functionHandler: (...args: unknown[]) => Promise<BridgeValue | null>,
+): T {
+  return new Proxy(functionHandler as unknown as object, {
+    get(_target, prop) {
+      if (prop === "then") {
+        return undefined;
+      }
+      if (typeof prop === "symbol") {
+        return undefined;
+      }
+
+      const childPath = `${currentPath}${PATH_SEPARATOR}${String(prop)}`;
+
+      if (metadata.isProperty(childPath)) {
+        if (metadata.isReadable(childPath)) {
+          return transport.get(childPath);
+        }
+      }
+
+      const childFunctionHandler = (
+        ...args: unknown[]
+      ): Promise<BridgeValue | null> => {
+        const bridgeArgs: BridgeValue[] = args.map((arg) =>
+          arg === undefined ? null : (arg as BridgeValue),
+        );
+        if (metadata.hasCapability(childPath)) {
+          return transport.invoke(childPath, bridgeArgs);
+        }
+        return Promise.resolve(null);
+      };
+
+      return createBridgeProxyInternal(
+        transport,
+        metadata,
+        childPath,
+        childFunctionHandler,
+      );
+    },
+
+    set(_target, prop, value) {
+      if (typeof prop === "symbol" || prop === "then") {
+        return false;
+      }
+      const childPath = `${currentPath}${PATH_SEPARATOR}${String(prop)}`;
+      if (metadata.hasCapability(childPath)) {
+        if (!metadata.isWritable(childPath)) {
+          throw new BridgeUnsupportedError(
+            `Property "${childPath}" is read-only on native.`,
+          );
+        }
+        const bridgeValue = value === undefined ? null : (value as BridgeValue);
+        void transport.set(childPath, bridgeValue);
+        return true;
+      }
+      return true;
+    },
+
+    apply(_target, _thisArg, argArray) {
+      return functionHandler(...argArray);
+    },
+  }) as unknown as T;
+}

--- a/packages/webview-bridge/src/bridge/types.d.ts
+++ b/packages/webview-bridge/src/bridge/types.d.ts
@@ -1,0 +1,26 @@
+import type {
+  BridgeCapabilityPayload,
+  BridgeMetadataPayload,
+} from "../protocol/types.d.ts";
+
+/**
+ * Parsed capability record in the runtime bridge.
+ */
+export interface BridgeCapability {
+  path: string;
+  kind: "function" | "property" | "namespace";
+  readable: boolean;
+  writable: boolean;
+}
+
+/**
+ * Runtime metadata describing active native bridge session and capabilities.
+ */
+export interface BridgeMetadata {
+  protocolVersion: number;
+  bridgeVersion: string;
+  sessionId: string;
+  capabilities: BridgeCapability[];
+}
+
+export type { BridgeCapabilityPayload, BridgeMetadataPayload };

--- a/packages/webview-bridge/src/endpoint/android.legacy.ts
+++ b/packages/webview-bridge/src/endpoint/android.legacy.ts
@@ -1,0 +1,139 @@
+import type {
+  AndroidJavascriptInterfaceObject,
+  NativeEndpoint,
+  NativeMessageHandler,
+} from "./types.d.ts";
+import {
+  getGlobalWindowProperty,
+  safelyDispatchHandlers,
+  sanitizeIdentifier,
+} from "./utils.ts";
+
+/**
+ * Global window receiver interface for legacy native-to-JS callbacks.
+ */
+type LegacyReceiverFunction = (rawMessage: string) => void;
+
+/**
+ * Android Legacy Endpoint using WebView `addJavascriptInterface`.
+ *
+ * Supports both:
+ * 1. Synchronous string return values from native `@JavascriptInterface fun postMessage(rawJson: String): String?`
+ * 2. Asynchronous native dispatches to `window.__<sanitizedName>_legacy_receive__(message)`
+ */
+export class AndroidLegacyEndpoint implements NativeEndpoint {
+  public readonly name: string;
+  public readonly platform = "android-legacy" as const;
+
+  private readonly listeners = new Set<NativeMessageHandler>();
+  private targetObject: AndroidJavascriptInterfaceObject | null = null;
+  private readonly callbackName: string;
+  private isDisposed = false;
+
+  constructor(name: string) {
+    this.name = name;
+    this.callbackName = `__${sanitizeIdentifier(name)}_legacy_receive__`;
+    this.initialize();
+  }
+
+  /**
+   * Static detector: checks if Android Legacy `addJavascriptInterface` object is available on `window`.
+   */
+  public static isAvailable(name: string): boolean {
+    const obj = getGlobalWindowProperty<AndroidJavascriptInterfaceObject>(name);
+    if (!obj || typeof obj.postMessage !== "function") {
+      return false;
+    }
+    // Android Legacy interface does NOT have addEventListener or onmessage properties
+    return (
+      !("onmessage" in obj) &&
+      typeof (obj as unknown as Record<string, unknown>).addEventListener !==
+        "function"
+    );
+  }
+
+  private initialize(): void {
+    const obj = getGlobalWindowProperty<AndroidJavascriptInterfaceObject>(
+      this.name,
+    );
+    if (!obj || typeof obj.postMessage !== "function") {
+      throw new Error(
+        `Android Legacy interface "${this.name}" is not available on window.`,
+      );
+    }
+
+    this.targetObject = obj;
+
+    // Install scoped global receiver on window so native evaluateJavascript can invoke it for async dispatches
+    if (typeof window !== "undefined") {
+      const windowRecord = window as unknown as Record<string, unknown>;
+
+      const receiver: LegacyReceiverFunction = (rawMessage: string) => {
+        if (this.isDisposed) {
+          return;
+        }
+        if (typeof rawMessage === "string") {
+          safelyDispatchHandlers(this.listeners, rawMessage);
+        }
+      };
+
+      windowRecord[this.callbackName] = receiver;
+    }
+  }
+
+  public postMessage(message: string): void {
+    if (this.isDisposed || !this.targetObject) {
+      throw new Error(
+        `Android Legacy endpoint "${this.name}" is disposed or unavailable.`,
+      );
+    }
+
+    try {
+      // Execute postMessage call on injected Android JavascriptInterface object
+      const result = this.targetObject.postMessage(message);
+
+      // Handle synchronous return string from native @JavascriptInterface method
+      if (result !== undefined && result !== null) {
+        const replyString =
+          typeof result === "string" ? result : String(result);
+        if (replyString.trim() !== "") {
+          safelyDispatchHandlers(this.listeners, replyString);
+        }
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to post message on Android Legacy endpoint "${this.name}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  public onMessage(handler: NativeMessageHandler): () => void {
+    if (this.isDisposed) {
+      return () => {};
+    }
+    this.listeners.add(handler);
+    return () => {
+      this.listeners.delete(handler);
+    };
+  }
+
+  public dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+
+    // Remove legacy callback from window
+    if (typeof window !== "undefined") {
+      const windowRecord = window as unknown as Record<string, unknown>;
+      if (this.callbackName in windowRecord) {
+        delete windowRecord[this.callbackName];
+      }
+    }
+
+    this.listeners.clear();
+    this.targetObject = null;
+  }
+}

--- a/packages/webview-bridge/src/endpoint/android.ts
+++ b/packages/webview-bridge/src/endpoint/android.ts
@@ -1,0 +1,138 @@
+import type {
+  AndroidWebMessageListenerObject,
+  NativeEndpoint,
+  NativeMessageHandler,
+  WebMessageObject,
+} from "./types.d.ts";
+import { getGlobalWindowProperty, safelyDispatchHandlers } from "./utils.ts";
+
+/**
+ * Android Modern Endpoint using AndroidX WebKit `addWebMessageListener`.
+ * Receives messages via `window[name].onmessage` or `addEventListener('message')`.
+ * Sends messages via `window[name].postMessage(message)`.
+ */
+export class AndroidModernEndpoint implements NativeEndpoint {
+  public readonly name: string;
+  public readonly platform = "android-modern" as const;
+
+  private readonly listeners = new Set<NativeMessageHandler>();
+  private targetObject: AndroidWebMessageListenerObject | null = null;
+  private boundEventListener: ((event: WebMessageObject) => void) | null = null;
+  private isDisposed = false;
+
+  constructor(name: string) {
+    this.name = name;
+    this.initialize();
+  }
+
+  /**
+   * Static detector: checks if Android Modern `addWebMessageListener` is available
+   * for the given endpoint name on `window`.
+   * Android Modern objects feature an `onmessage` property or `addEventListener` function.
+   */
+  public static isAvailable(name: string): boolean {
+    const obj = getGlobalWindowProperty<AndroidWebMessageListenerObject>(name);
+    if (!obj || typeof obj.postMessage !== "function") {
+      return false;
+    }
+    // Android Modern WebMessageListener provides onmessage property or addEventListener
+    return "onmessage" in obj || typeof obj.addEventListener === "function";
+  }
+
+  private initialize(): void {
+    const obj = getGlobalWindowProperty<AndroidWebMessageListenerObject>(
+      this.name,
+    );
+    if (!obj || typeof obj.postMessage !== "function") {
+      throw new Error(
+        `Android Modern WebMessageListener "${this.name}" is not available on window.`,
+      );
+    }
+
+    this.targetObject = obj;
+
+    // Create the message receiver callback
+    this.boundEventListener = (event: WebMessageObject) => {
+      if (this.isDisposed) {
+        return;
+      }
+      let rawData: string;
+      if (typeof event.data === "string") {
+        rawData = event.data;
+      } else if (event.data !== null && event.data !== undefined) {
+        rawData = String(event.data);
+      } else {
+        return;
+      }
+      safelyDispatchHandlers(this.listeners, rawData);
+    };
+
+    // Attach via addEventListener if available, otherwise set onmessage
+    if (typeof obj.addEventListener === "function") {
+      obj.addEventListener("message", this.boundEventListener);
+    } else {
+      const existingOnMessage = obj.onmessage;
+      obj.onmessage = (event: WebMessageObject) => {
+        if (typeof existingOnMessage === "function") {
+          try {
+            existingOnMessage(event);
+          } catch {
+            // Isolate existing handler
+          }
+        }
+        if (this.boundEventListener) {
+          this.boundEventListener(event);
+        }
+      };
+    }
+  }
+
+  public postMessage(message: string): void {
+    if (this.isDisposed || !this.targetObject) {
+      throw new Error(
+        `Android Modern endpoint "${this.name}" is disposed or unavailable.`,
+      );
+    }
+    try {
+      this.targetObject.postMessage(message);
+    } catch (error) {
+      throw new Error(
+        `Failed to post message on Android Modern endpoint "${this.name}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  public onMessage(handler: NativeMessageHandler): () => void {
+    if (this.isDisposed) {
+      return () => {};
+    }
+    this.listeners.add(handler);
+    return () => {
+      this.listeners.delete(handler);
+    };
+  }
+
+  public dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+
+    if (this.targetObject && this.boundEventListener) {
+      if (typeof this.targetObject.removeEventListener === "function") {
+        this.targetObject.removeEventListener(
+          "message",
+          this.boundEventListener,
+        );
+      } else if (this.targetObject.onmessage === this.boundEventListener) {
+        this.targetObject.onmessage = null;
+      }
+    }
+
+    this.listeners.clear();
+    this.targetObject = null;
+    this.boundEventListener = null;
+  }
+}

--- a/packages/webview-bridge/src/endpoint/android.ts
+++ b/packages/webview-bridge/src/endpoint/android.ts
@@ -18,6 +18,9 @@ export class AndroidModernEndpoint implements NativeEndpoint {
   private readonly listeners = new Set<NativeMessageHandler>();
   private targetObject: AndroidWebMessageListenerObject | null = null;
   private boundEventListener: ((event: WebMessageObject) => void) | null = null;
+  private installedOnMessage: ((event: WebMessageObject) => void) | null = null;
+  private previousOnMessage:
+    ((event: WebMessageObject) => void) | null | undefined = undefined;
   private isDisposed = false;
 
   constructor(name: string) {
@@ -67,12 +70,13 @@ export class AndroidModernEndpoint implements NativeEndpoint {
       safelyDispatchHandlers(this.listeners, rawData);
     };
 
-    // Attach via addEventListener if available, otherwise set onmessage
+    // Attach via addEventListener if available, otherwise set onmessage wrapper safely
     if (typeof obj.addEventListener === "function") {
       obj.addEventListener("message", this.boundEventListener);
     } else {
       const existingOnMessage = obj.onmessage;
-      obj.onmessage = (event: WebMessageObject) => {
+      this.previousOnMessage = existingOnMessage ?? null;
+      this.installedOnMessage = (event: WebMessageObject) => {
         if (typeof existingOnMessage === "function") {
           try {
             existingOnMessage(event);
@@ -84,6 +88,7 @@ export class AndroidModernEndpoint implements NativeEndpoint {
           this.boundEventListener(event);
         }
       };
+      obj.onmessage = this.installedOnMessage;
     }
   }
 
@@ -120,19 +125,27 @@ export class AndroidModernEndpoint implements NativeEndpoint {
     }
     this.isDisposed = true;
 
-    if (this.targetObject && this.boundEventListener) {
-      if (typeof this.targetObject.removeEventListener === "function") {
+    if (this.targetObject) {
+      if (
+        this.boundEventListener &&
+        typeof this.targetObject.removeEventListener === "function"
+      ) {
         this.targetObject.removeEventListener(
           "message",
           this.boundEventListener,
         );
-      } else if (this.targetObject.onmessage === this.boundEventListener) {
-        this.targetObject.onmessage = null;
+      } else if (
+        this.installedOnMessage &&
+        this.targetObject.onmessage === this.installedOnMessage
+      ) {
+        this.targetObject.onmessage = this.previousOnMessage ?? null;
       }
     }
 
     this.listeners.clear();
     this.targetObject = null;
     this.boundEventListener = null;
+    this.installedOnMessage = null;
+    this.previousOnMessage = undefined;
   }
 }

--- a/packages/webview-bridge/src/endpoint/ios.ts
+++ b/packages/webview-bridge/src/endpoint/ios.ts
@@ -1,0 +1,155 @@
+import type {
+  NativeEndpoint,
+  NativeMessageHandler,
+  WKScriptMessageHandlerObject,
+} from "./types.d.ts";
+import {
+  getNestedGlobalProperty,
+  safelyDispatchHandlers,
+  sanitizeIdentifier,
+} from "./utils.ts";
+
+/**
+ * iOS Endpoint using WebKit message handlers (`window.webkit.messageHandlers[name]`).
+ * Handles both `WKScriptMessageHandlerWithReply` (Promise return values) and unsolicited native
+ * messages dispatched to `window.__<sanitizedName>_ios_receive__(message)`.
+ */
+export class IOSEndpoint implements NativeEndpoint {
+  public readonly name: string;
+  public readonly platform = "ios" as const;
+
+  private readonly listeners = new Set<NativeMessageHandler>();
+  private targetHandler: WKScriptMessageHandlerObject | null = null;
+  private readonly callbackName: string;
+  private isDisposed = false;
+
+  constructor(name: string) {
+    this.name = name;
+    this.callbackName = `__${sanitizeIdentifier(name)}_ios_receive__`;
+    this.initialize();
+  }
+
+  /**
+   * Static detector: checks if iOS WebKit message handler object is available on `window.webkit.messageHandlers[name]`.
+   */
+  public static isAvailable(name: string): boolean {
+    const handler = getNestedGlobalProperty<WKScriptMessageHandlerObject>([
+      "webkit",
+      "messageHandlers",
+      name,
+    ]);
+    if (!handler || typeof handler.postMessage !== "function") {
+      return false;
+    }
+    return true;
+  }
+
+  private initialize(): void {
+    const handler = getNestedGlobalProperty<WKScriptMessageHandlerObject>([
+      "webkit",
+      "messageHandlers",
+      this.name,
+    ]);
+    if (!handler || typeof handler.postMessage !== "function") {
+      throw new Error(
+        `iOS WebKit message handler "${this.name}" is not available.`,
+      );
+    }
+
+    this.targetHandler = handler;
+
+    // Install scoped global receiver on window for native events / standard handlers
+    if (typeof window !== "undefined") {
+      const windowRecord = window as unknown as Record<string, unknown>;
+      windowRecord[this.callbackName] = (rawMessage: unknown) => {
+        if (this.isDisposed) {
+          return;
+        }
+        const stringMessage =
+          typeof rawMessage === "string" ? rawMessage : String(rawMessage);
+        safelyDispatchHandlers(this.listeners, stringMessage);
+      };
+    }
+  }
+
+  public postMessage(message: string): void {
+    if (this.isDisposed || !this.targetHandler) {
+      throw new Error(
+        `iOS WebKit endpoint "${this.name}" is disposed or unavailable.`,
+      );
+    }
+
+    try {
+      const result = this.targetHandler.postMessage(message);
+
+      // Handle WKScriptMessageHandlerWithReply Promise return value
+      if (
+        result !== null &&
+        typeof result === "object" &&
+        typeof (result as Promise<unknown>).then === "function"
+      ) {
+        (result as Promise<unknown>)
+          .then((replyPayload: unknown) => {
+            if (this.isDisposed) {
+              return;
+            }
+            if (replyPayload !== undefined && replyPayload !== null) {
+              const replyString =
+                typeof replyPayload === "string"
+                  ? replyPayload
+                  : JSON.stringify(replyPayload);
+              safelyDispatchHandlers(this.listeners, replyString);
+            }
+          })
+          .catch((error: unknown) => {
+            if (this.isDisposed) {
+              return;
+            }
+            if (
+              typeof console !== "undefined" &&
+              typeof console.error === "function"
+            ) {
+              console.error(
+                `iOS WebKit reply handler error for endpoint "${this.name}":`,
+                error,
+              );
+            }
+          });
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to post message on iOS WebKit endpoint "${this.name}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  public onMessage(handler: NativeMessageHandler): () => void {
+    if (this.isDisposed) {
+      return () => {};
+    }
+    this.listeners.add(handler);
+    return () => {
+      this.listeners.delete(handler);
+    };
+  }
+
+  public dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+
+    // Clean up window receiver callback
+    if (typeof window !== "undefined") {
+      const windowRecord = window as unknown as Record<string, unknown>;
+      if (this.callbackName in windowRecord) {
+        delete windowRecord[this.callbackName];
+      }
+    }
+
+    this.listeners.clear();
+    this.targetHandler = null;
+  }
+}

--- a/packages/webview-bridge/src/endpoint/ios.ts
+++ b/packages/webview-bridge/src/endpoint/ios.ts
@@ -98,10 +98,12 @@ export class IOSEndpoint implements NativeEndpoint {
                 typeof replyPayload === "string"
                   ? replyPayload
                   : JSON.stringify(replyPayload);
-              safelyDispatchHandlers(this.listeners, replyString);
+              if (typeof replyString === "string") {
+                safelyDispatchHandlers(this.listeners, replyString);
+              }
             }
           })
-          .catch((error: unknown) => {
+          .catch(() => {
             if (this.isDisposed) {
               return;
             }
@@ -110,8 +112,7 @@ export class IOSEndpoint implements NativeEndpoint {
               typeof console.error === "function"
             ) {
               console.error(
-                `iOS WebKit reply handler error for endpoint "${this.name}":`,
-                error,
+                `iOS WebKit reply handler rejected for endpoint "${this.name}".`,
               );
             }
           });

--- a/packages/webview-bridge/src/endpoint/ios.ts
+++ b/packages/webview-bridge/src/endpoint/ios.ts
@@ -103,7 +103,7 @@ export class IOSEndpoint implements NativeEndpoint {
               }
             }
           })
-          .catch(() => {
+          .catch((error: unknown) => {
             if (this.isDisposed) {
               return;
             }
@@ -114,6 +114,30 @@ export class IOSEndpoint implements NativeEndpoint {
               console.error(
                 `iOS WebKit reply handler rejected for endpoint "${this.name}".`,
               );
+            }
+
+            // Extract request id from message payload to reject pending invoke immediately
+            try {
+              const parsed = JSON.parse(message);
+              if (parsed && typeof parsed.id === "string") {
+                const errorMsg =
+                  error instanceof Error
+                    ? error.message
+                    : String(error || "iOS native handler rejected");
+                const syntheticErrorReply = JSON.stringify({
+                  type: "reply",
+                  operation: parsed.operation || "invoke",
+                  id: parsed.id,
+                  status: "error",
+                  error: {
+                    code: "NATIVE_ERROR",
+                    message: `iOS WebKit reply handler rejected: ${errorMsg}`,
+                  },
+                });
+                safelyDispatchHandlers(this.listeners, syntheticErrorReply);
+              }
+            } catch {
+              // Ignore if outbound request string is malformed
             }
           });
       }

--- a/packages/webview-bridge/src/endpoint/native-endpoint.ts
+++ b/packages/webview-bridge/src/endpoint/native-endpoint.ts
@@ -1,0 +1,37 @@
+import { DEFAULT_BRIDGE_NAME } from "../protocol/constants.ts";
+import { AndroidModernEndpoint } from "./android.ts";
+import { AndroidLegacyEndpoint } from "./android.legacy.ts";
+import { IOSEndpoint } from "./ios.ts";
+import type { NativeEndpoint } from "./types.d.ts";
+
+/**
+ * Endpoint discovery factory.
+ * Inspects runtime environment for native WebView messaging capabilities:
+ * 1. iOS WebKit message handler (`window.webkit.messageHandlers[name]`)
+ * 2. Android Modern WebMessageListener (`window[name]`)
+ * 3. Android Legacy JavascriptInterface (`window[name]`)
+ *
+ * Returns a unified `NativeEndpoint` platform adapter, or `null` if no platform
+ * endpoint is available.
+ */
+export function createNativeEndpoint(
+  endpointName: string = DEFAULT_BRIDGE_NAME,
+): NativeEndpoint | null {
+  const name =
+    (typeof endpointName === "string" ? endpointName : "").trim() ||
+    DEFAULT_BRIDGE_NAME;
+
+  if (IOSEndpoint.isAvailable(name)) {
+    return new IOSEndpoint(name);
+  }
+
+  if (AndroidModernEndpoint.isAvailable(name)) {
+    return new AndroidModernEndpoint(name);
+  }
+
+  if (AndroidLegacyEndpoint.isAvailable(name)) {
+    return new AndroidLegacyEndpoint(name);
+  }
+
+  return null;
+}

--- a/packages/webview-bridge/src/endpoint/types.d.ts
+++ b/packages/webview-bridge/src/endpoint/types.d.ts
@@ -1,0 +1,89 @@
+/**
+ * Callback handler for raw incoming messages from native.
+ * Operating exclusively on raw string payloads.
+ */
+export type NativeMessageHandler = (message: string) => void;
+
+/**
+ * Platform endpoint classifier.
+ */
+export type EndpointPlatform =
+  "android-modern" | "android-legacy" | "ios" | "unknown";
+
+/**
+ * Lowest-level JavaScript abstraction over platform WebView message channels.
+ * Operates purely on strings and has no knowledge of protocol JSON, request IDs,
+ * promises, metadata, or application contracts.
+ */
+export interface NativeEndpoint {
+  /** The endpoint registration name (e.g. "NativeBridge") */
+  readonly name: string;
+
+  /** The detected underlying platform mechanism */
+  readonly platform: EndpointPlatform;
+
+  /**
+   * Post a raw string message to the native platform handler.
+   * Throws if the underlying native endpoint is unavailable or disconnected.
+   */
+  postMessage(message: string): void;
+
+  /**
+   * Subscribe a message handler to receive incoming raw string messages from native.
+   * Returns an unsubscribe function.
+   */
+  onMessage(handler: NativeMessageHandler): () => void;
+
+  /**
+   * Clean up all native message listeners, window callback handlers, and resources.
+   */
+  dispose(): void;
+}
+
+/**
+ * WebMessage event interface injected by Android WebView addWebMessageListener.
+ */
+export interface WebMessageObject {
+  data?: unknown;
+  origin?: string;
+  ports?: unknown[];
+}
+
+/**
+ * Window object listener interface injected by Android WebView addWebMessageListener.
+ */
+export interface AndroidWebMessageListenerObject {
+  postMessage(message: string): void;
+  onmessage?: ((event: WebMessageObject) => void) | null;
+  addEventListener?(
+    type: string,
+    listener: (event: WebMessageObject) => void,
+  ): void;
+  removeEventListener?(
+    type: string,
+    listener: (event: WebMessageObject) => void,
+  ): void;
+}
+
+/**
+ * Window object interface injected by Android WebView addJavascriptInterface.
+ * In Android Java/Kotlin, @JavascriptInterface methods can return String synchronously,
+ * or void with asynchronous callback dispatches.
+ */
+export interface AndroidJavascriptInterfaceObject {
+  postMessage(message: string): unknown;
+}
+
+/**
+ * iOS WebKit script message handler interface.
+ */
+export interface WKScriptMessageHandlerObject {
+  postMessage(message: unknown): Promise<unknown> | void;
+}
+
+/**
+ * iOS WebKit message handlers container interface on window.webkit.messageHandlers.
+ */
+export interface WKWebkitContainer {
+  messageHandlers?: Record<string, WKScriptMessageHandlerObject | undefined>;
+}

--- a/packages/webview-bridge/src/endpoint/utils.ts
+++ b/packages/webview-bridge/src/endpoint/utils.ts
@@ -32,11 +32,14 @@ export function getNestedGlobalProperty<T>(
 }
 
 /**
- * Sanitize an endpoint name into a safe valid JavaScript identifier suffix.
- * Replaces non-alphanumeric characters with underscores.
+ * Sanitize an endpoint name into an injective JavaScript identifier suffix.
+ * Encodes non-alphanumeric characters using their hex character code to prevent collision.
  */
 export function sanitizeIdentifier(name: string): string {
-  return name.replace(/[^a-zA-Z0-9_$]/g, "_");
+  return name.replace(
+    /[^a-zA-Z0-9_$]/g,
+    (ch) => `_${ch.charCodeAt(0).toString(16)}_`,
+  );
 }
 
 /**

--- a/packages/webview-bridge/src/endpoint/utils.ts
+++ b/packages/webview-bridge/src/endpoint/utils.ts
@@ -1,0 +1,68 @@
+/**
+ * Safely inspect properties on the global `window` object without `any`.
+ */
+export function getGlobalWindowProperty<T>(
+  propertyName: string,
+): T | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  const windowRecord = window as unknown as Record<string, unknown>;
+  const prop = windowRecord[propertyName];
+  return prop as T | undefined;
+}
+
+/**
+ * Safely inspect nested object properties on `window` (e.g. "webkit.messageHandlers").
+ */
+export function getNestedGlobalProperty<T>(
+  path: readonly string[],
+): T | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  let current: unknown = window;
+  for (const segment of path) {
+    if (current === null || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current as T | undefined;
+}
+
+/**
+ * Sanitize an endpoint name into a safe valid JavaScript identifier suffix.
+ * Replaces non-alphanumeric characters with underscores.
+ */
+export function sanitizeIdentifier(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_$]/g, "_");
+}
+
+/**
+ * Dispatches an event payload string to a Set of message handlers safely.
+ * Isolates subscriber exceptions so one failing handler never prevents others
+ * from receiving the message.
+ */
+export function safelyDispatchHandlers(
+  handlers: Set<(message: string) => void>,
+  message: string,
+): void {
+  const handlerSnapshot = Array.from(handlers);
+  for (const handler of handlerSnapshot) {
+    try {
+      handler(message);
+    } catch (error) {
+      // Isolate handler failure from breaking remaining dispatches
+      if (
+        typeof console !== "undefined" &&
+        typeof console.error === "function"
+      ) {
+        console.error(
+          "Unhandled exception in NativeEndpoint message handler:",
+          error,
+        );
+      }
+    }
+  }
+}

--- a/packages/webview-bridge/src/index.ts
+++ b/packages/webview-bridge/src/index.ts
@@ -1,0 +1,39 @@
+export {
+  buildNativeBridge,
+  clearNativeBridgeCache,
+} from "./bridge/build-native-bridge.ts";
+export type { BuildBridgeOptions } from "./bridge/build-native-bridge.ts";
+
+// Structured Errors
+export {
+  BridgeError,
+  BridgeInitializationError,
+  BridgeTransportError,
+  BridgeTimeoutError,
+  BridgeProtocolError,
+  BridgeNativeError,
+  BridgeUnsupportedError,
+} from "./transport/errors.ts";
+
+// Protocol & Bridge Type Exports
+export type {
+  BridgePrimitive,
+  BridgeValue,
+  BridgeRequest,
+  BridgeReply,
+  BridgeEvent,
+  BridgeMessage,
+  BridgeCapabilityPayload,
+  BridgeMetadataPayload,
+} from "./protocol/types.d.ts";
+
+export type { BridgeCapability, BridgeMetadata } from "./bridge/types.d.ts";
+export type {
+  NativeEndpoint,
+  NativeMessageHandler,
+  EndpointPlatform,
+} from "./endpoint/types.d.ts";
+export type {
+  NativeTransport,
+  BridgeEventHandler,
+} from "./transport/types.d.ts";

--- a/packages/webview-bridge/src/protocol/codec.ts
+++ b/packages/webview-bridge/src/protocol/codec.ts
@@ -1,0 +1,169 @@
+import { MESSAGE_TYPES, OPERATIONS, REPLY_STATUS } from "./constants.ts";
+import type {
+  BridgeEvent,
+  BridgeMessage,
+  BridgeReply,
+  BridgeRequest,
+  BridgeValue,
+} from "./types.d.ts";
+
+/**
+ * @zod-candidate This manual structural type guard can be replaced with a Zod schema in zero-dependency-free environments.
+ * Validates if an unknown value is a JSON-safe BridgeValue.
+ * Disallows undefined, functions, symbols, BigInt, Date, Map, Set, class instances.
+ */
+export function isBridgeValue(val: unknown): val is BridgeValue {
+  if (
+    val === null ||
+    typeof val === "boolean" ||
+    typeof val === "number" ||
+    typeof val === "string"
+  ) {
+    return true;
+  }
+  if (typeof val !== "object") {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(val);
+  if (Array.isArray(val)) {
+    return val.every(isBridgeValue);
+  }
+  if (proto !== null && proto !== Object.prototype) {
+    return false;
+  }
+  return Object.values(val as Record<string, unknown>).every(isBridgeValue);
+}
+
+/**
+ * @zod-candidate Can be replaced with Zod schema validation.
+ * Validates if an unknown value matches the BridgeReply interface.
+ */
+export function isBridgeReply(val: unknown): val is BridgeReply {
+  if (val === null || typeof val !== "object") {
+    return false;
+  }
+  const obj = val as Record<string, unknown>;
+  const type = obj["type"];
+  if (type !== MESSAGE_TYPES.REPLY && type !== MESSAGE_TYPES.ACK) {
+    return false;
+  }
+  if (typeof obj["id"] !== "string" || obj["id"] === "") {
+    return false;
+  }
+  const status = obj["status"];
+  if (
+    status &&
+    status !== REPLY_STATUS.SUCCESS &&
+    status !== REPLY_STATUS.ACK &&
+    status !== REPLY_STATUS.ERROR
+  ) {
+    return false;
+  }
+  const op = obj["operation"];
+  if (
+    op !== OPERATIONS.INIT &&
+    op !== OPERATIONS.INVOKE &&
+    op !== OPERATIONS.GET &&
+    op !== OPERATIONS.SET
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @zod-candidate Can be replaced with Zod schema validation.
+ * Validates if an unknown value matches the BridgeEvent interface.
+ */
+export function isBridgeEvent(val: unknown): val is BridgeEvent {
+  if (val === null || typeof val !== "object") {
+    return false;
+  }
+  const obj = val as Record<string, unknown>;
+  if (obj["type"] !== MESSAGE_TYPES.EVENT) {
+    return false;
+  }
+  if (typeof obj["name"] !== "string" || obj["name"] === "") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @zod-candidate Can be replaced with Zod schema validation.
+ * Validates if an unknown value matches any BridgeRequest structure.
+ */
+export function isBridgeRequest(val: unknown): val is BridgeRequest {
+  if (val === null || typeof val !== "object") {
+    return false;
+  }
+  const obj = val as Record<string, unknown>;
+  if (obj["type"] !== MESSAGE_TYPES.REQUEST) {
+    return false;
+  }
+  if (typeof obj["id"] !== "string" || obj["id"] === "") {
+    return false;
+  }
+  const op = obj["operation"];
+  if (
+    op !== OPERATIONS.INIT &&
+    op !== OPERATIONS.INVOKE &&
+    op !== OPERATIONS.GET &&
+    op !== OPERATIONS.SET
+  ) {
+    return false;
+  }
+  if (typeof obj["payload"] !== "object" || obj["payload"] === null) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @zod-candidate Can be replaced with Zod discriminated union schema (z.discriminatedUnion('type', [...])).
+ * Validates if an unknown value matches any BridgeMessage structure.
+ */
+export function isBridgeMessage(val: unknown): val is BridgeMessage {
+  if (val === null || typeof val !== "object") {
+    return false;
+  }
+  const obj = val as Record<string, unknown>;
+  const type = obj["type"];
+  if (type === MESSAGE_TYPES.REPLY || type === MESSAGE_TYPES.ACK) {
+    return isBridgeReply(val);
+  }
+  if (type === MESSAGE_TYPES.EVENT) {
+    return isBridgeEvent(val);
+  }
+  if (type === MESSAGE_TYPES.REQUEST) {
+    return isBridgeRequest(val);
+  }
+  return false;
+}
+
+/**
+ * Encodes a BridgeMessage object into a JSON string.
+ */
+export function encodeBridgeMessage(message: BridgeMessage): string {
+  return JSON.stringify(message);
+}
+
+/**
+ * Decodes a raw string message into a validated BridgeMessage object.
+ * Returns `null` if the message is malformed or invalid JSON. Never throws.
+ */
+export function decodeBridgeMessage(rawMessage: string): BridgeMessage | null {
+  if (typeof rawMessage !== "string" || rawMessage.trim() === "") {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(rawMessage);
+    if (isBridgeMessage(parsed)) {
+      return parsed;
+    }
+    return null;
+  } catch {
+    // Malformed JSON is safely caught and ignored at protocol boundary
+    return null;
+  }
+}

--- a/packages/webview-bridge/src/protocol/codec.ts
+++ b/packages/webview-bridge/src/protocol/codec.ts
@@ -52,7 +52,6 @@ export function isBridgeReply(val: unknown): val is BridgeReply {
   }
   const status = obj["status"];
   if (
-    status &&
     status !== REPLY_STATUS.SUCCESS &&
     status !== REPLY_STATUS.ACK &&
     status !== REPLY_STATUS.ERROR
@@ -84,6 +83,9 @@ export function isBridgeEvent(val: unknown): val is BridgeEvent {
     return false;
   }
   if (typeof obj["name"] !== "string" || obj["name"] === "") {
+    return false;
+  }
+  if (!("payload" in obj) || !isBridgeValue(obj["payload"])) {
     return false;
   }
   return true;

--- a/packages/webview-bridge/src/protocol/constants.ts
+++ b/packages/webview-bridge/src/protocol/constants.ts
@@ -1,0 +1,49 @@
+/**
+ * Current supported protocol version.
+ */
+export const PROTOCOL_VERSION = 1;
+
+/**
+ * Client JavaScript library version.
+ */
+export const CLIENT_VERSION = "0.1.1";
+
+/**
+ * Default bridge registration name on window.
+ */
+export const DEFAULT_BRIDGE_NAME = "NativeBridge";
+
+/**
+ * Protocol path namespace separator.
+ * Used for protocol-level paths (e.g. "systemBars:hideStatusBar").
+ */
+export const PATH_SEPARATOR = ":";
+
+/**
+ * Protocol message types.
+ */
+export const MESSAGE_TYPES = {
+  REQUEST: "request",
+  REPLY: "reply",
+  ACK: "ack",
+  EVENT: "event",
+} as const;
+
+/**
+ * Protocol operations.
+ */
+export const OPERATIONS = {
+  INIT: "init",
+  INVOKE: "invoke",
+  GET: "get",
+  SET: "set",
+} as const;
+
+/**
+ * Protocol reply statuses.
+ */
+export const REPLY_STATUS = {
+  SUCCESS: "success",
+  ACK: "ack",
+  ERROR: "error",
+} as const;

--- a/packages/webview-bridge/src/protocol/types.d.ts
+++ b/packages/webview-bridge/src/protocol/types.d.ts
@@ -1,0 +1,155 @@
+/**
+ * JSON-primitive value types allowed in bridge messages.
+ */
+export type BridgePrimitive = string | number | boolean | null;
+
+/**
+ * Recursive JSON-safe value type for bridge messages.
+ * Functions, symbols, undefined, BigInt, Date, Map, Set, and class instances are disallowed.
+ */
+export type BridgeValue =
+  BridgePrimitive | BridgeValue[] | { [key: string]: BridgeValue };
+
+/**
+ * Structured error details transmitted from native in a BridgeReply.
+ */
+export interface BridgeErrorPayload {
+  code: string;
+  message: string;
+  details?: BridgeValue;
+}
+
+/**
+ * Capability description payload returned from native during initialization.
+ */
+export interface BridgeCapabilityPayload {
+  /** Protocol path using colon separator (e.g. "systemBars:hideStatusBar") */
+  path: string;
+  /** Kind of member */
+  kind: "function" | "property" | "namespace";
+  /** Whether property supports get operation */
+  readable?: boolean;
+  /** Whether property supports set operation */
+  writable?: boolean;
+}
+
+/**
+ * Metadata payload returned from native during initialization.
+ */
+export interface BridgeMetadataPayload {
+  protocolVersion: number;
+  bridgeVersion: string;
+  sessionId: string;
+  capabilities: BridgeCapabilityPayload[];
+}
+
+/**
+ * Initialization request payload.
+ */
+export interface BridgeInitPayload {
+  bridgeName: string;
+  clientVersion: string;
+  sessionId?: string;
+}
+
+/**
+ * Method invocation request payload.
+ */
+export interface BridgeInvokePayload {
+  path: string;
+  args: BridgeValue[];
+  sessionId?: string;
+}
+
+/**
+ * Property get request payload.
+ */
+export interface BridgeGetPayload {
+  path: string;
+  sessionId?: string;
+}
+
+/**
+ * Property set request payload.
+ */
+export interface BridgeSetPayload {
+  path: string;
+  value: BridgeValue;
+  sessionId?: string;
+}
+
+/**
+ * Initialization request sent to native to establish session and retrieve capability metadata.
+ */
+export interface BridgeInitRequest {
+  type: "request";
+  operation: "init";
+  id: string;
+  protocolVersion: number;
+  payload: BridgeInitPayload;
+}
+
+/**
+ * Method invocation request.
+ */
+export interface BridgeInvokeRequest {
+  type: "request";
+  operation: "invoke";
+  id: string;
+  payload: BridgeInvokePayload;
+}
+
+/**
+ * Property get request.
+ */
+export interface BridgeGetRequest {
+  type: "request";
+  operation: "get";
+  id: string;
+  payload: BridgeGetPayload;
+}
+
+/**
+ * Property set request.
+ */
+export interface BridgeSetRequest {
+  type: "request";
+  operation: "set";
+  id: string;
+  payload: BridgeSetPayload;
+}
+
+/**
+ * Union of all outbound request messages from JS to Native.
+ */
+export type BridgeRequest =
+  BridgeInitRequest | BridgeInvokeRequest | BridgeGetRequest | BridgeSetRequest;
+
+/**
+ * Uniform response message sent from Native to JS correlated by request `id`.
+ * Contains `status: "ack"` or `type: "ack"` for void methods without a return payload.
+ * Contains `status: "success"` and `result` payload when returning a value or null.
+ * Contains `status: "error"` and `error` payload on failure.
+ */
+export interface BridgeReply {
+  type: "reply" | "ack";
+  operation: "init" | "invoke" | "get" | "set";
+  id: string;
+  status: "success" | "ack" | "error";
+  result?: BridgeValue;
+  error?: BridgeErrorPayload;
+}
+
+/**
+ * Unsolicited event message sent from Native to JS.
+ */
+export interface BridgeEvent {
+  type: "event";
+  name: string;
+  payload: BridgeValue;
+}
+
+/**
+ * Complete discriminated union of protocol messages.
+ */
+export type BridgeMessage = BridgeRequest | BridgeReply | BridgeEvent;

--- a/packages/webview-bridge/src/transport/errors.ts
+++ b/packages/webview-bridge/src/transport/errors.ts
@@ -1,0 +1,88 @@
+import type { BridgeValue } from "../protocol/types.d.ts";
+
+/**
+ * Abstract base class for all bridge-related errors.
+ */
+export abstract class BridgeError extends Error {
+  public readonly code: string;
+
+  constructor(message: string, code: string = "BRIDGE_ERROR") {
+    super(message);
+    this.name = this.constructor.name;
+    this.code = code;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Error thrown when bridge initialization fails or is rejected.
+ */
+export class BridgeInitializationError extends BridgeError {
+  constructor(message: string, code: string = "INIT_ERROR") {
+    super(message, code);
+  }
+}
+
+/**
+ * Error thrown when the underlying transport or native endpoint fails, disappears, or throws.
+ */
+export class BridgeTransportError extends BridgeError {
+  constructor(message: string, code: string = "TRANSPORT_ERROR") {
+    super(message, code);
+  }
+}
+
+/**
+ * Error thrown when a pending request exceeds its configured timeout duration.
+ */
+export class BridgeTimeoutError extends BridgeError {
+  public readonly requestId: string;
+
+  constructor(requestId: string, timeoutMs: number) {
+    super(
+      `Bridge request "${requestId}" timed out after ${timeoutMs}ms`,
+      "TIMEOUT_ERROR",
+    );
+    this.requestId = requestId;
+  }
+}
+
+/**
+ * Error thrown when protocol validation or payload structure checks fail.
+ */
+export class BridgeProtocolError extends BridgeError {
+  constructor(message: string, code: string = "PROTOCOL_ERROR") {
+    super(message, code);
+  }
+}
+
+/**
+ * Error thrown when a native platform operation returns an error status or exception.
+ */
+export class BridgeNativeError extends BridgeError {
+  public readonly details?: BridgeValue;
+
+  constructor(
+    message: string,
+    code: string = "NATIVE_ERROR",
+    details?: BridgeValue,
+  ) {
+    super(message, code);
+    this.details = details;
+  }
+}
+
+/**
+ * Error thrown when a lower-level direct transport operation targets an unsupported path or member.
+ */
+export class BridgeUnsupportedError extends BridgeError {
+  public readonly path: string;
+
+  constructor(path: string) {
+    super(
+      `Native capability "${path}" is unsupported on the current platform`,
+      "UNSUPPORTED_ERROR",
+    );
+    this.path = path;
+  }
+}

--- a/packages/webview-bridge/src/transport/native-transport.ts
+++ b/packages/webview-bridge/src/transport/native-transport.ts
@@ -1,0 +1,457 @@
+import { MetadataRegistry } from "../bridge/metadata.ts";
+import type { NativeEndpoint } from "../endpoint/types.d.ts";
+import {
+  decodeBridgeMessage,
+  encodeBridgeMessage,
+  isBridgeEvent,
+  isBridgeReply,
+} from "../protocol/codec.ts";
+import {
+  CLIENT_VERSION,
+  OPERATIONS,
+  MESSAGE_TYPES,
+  PROTOCOL_VERSION,
+  REPLY_STATUS,
+} from "../protocol/constants.ts";
+import type {
+  BridgeEvent,
+  BridgeInitPayload,
+  BridgeInitRequest,
+  BridgeMetadataPayload,
+  BridgeReply,
+  BridgeRequest,
+  BridgeValue,
+} from "../protocol/types.d.ts";
+import {
+  BridgeError,
+  BridgeInitializationError,
+  BridgeNativeError,
+  BridgeTimeoutError,
+  BridgeTransportError,
+} from "./errors.ts";
+import type {
+  BridgeEventHandler,
+  NativeTransport,
+  NativeTransportOptions,
+} from "./types.d.ts";
+
+/**
+ * Internal pending request tracker entry.
+ */
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (error: BridgeError) => void;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Robust RFC4122 v4 UUID generator with standard crypto.randomUUID and fallback mechanism.
+ */
+export function generateUUID(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    try {
+      return crypto.randomUUID();
+    } catch {
+      // Fallback if crypto.randomUUID is restricted in certain WebViews
+    }
+  }
+
+  // Fallback UUID v4 generator using Math.random
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Default implementation of NativeTransport protocol driver.
+ */
+export class DefaultNativeTransport implements NativeTransport {
+  public readonly endpoint: NativeEndpoint;
+  private readonly options: Required<NativeTransportOptions>;
+
+  private readonly pendingRequests = new Map<string, PendingRequest>();
+  private readonly eventSubscribers = new Map<
+    string,
+    Set<BridgeEventHandler>
+  >();
+
+  private endpointUnsubscribe: (() => void) | null = null;
+  private metadataRegistry: MetadataRegistry | null = null;
+  private activeSessionId: string | null = null;
+  private isDisposed = false;
+
+  constructor(endpoint: NativeEndpoint, options?: NativeTransportOptions) {
+    this.endpoint = endpoint;
+    this.options = {
+      defaultTimeoutMs: options?.defaultTimeoutMs ?? 0,
+    };
+    this.attachEndpointListener();
+  }
+
+  public get endpointName(): string {
+    return this.endpoint.name;
+  }
+
+  public get metadata(): BridgeMetadataPayload | null {
+    return this.metadataRegistry ? this.metadataRegistry.rawPayload : null;
+  }
+
+  public get isInitialized(): boolean {
+    return this.metadataRegistry !== null;
+  }
+
+  public get sessionId(): string | null {
+    return this.activeSessionId;
+  }
+
+  public async initialize(): Promise<BridgeMetadataPayload> {
+    if (this.isDisposed) {
+      throw new BridgeTransportError(
+        `Transport for endpoint "${this.endpoint.name}" is disposed.`,
+        this.endpoint.name,
+      );
+    }
+
+    if (this.metadataRegistry) {
+      return this.metadataRegistry.rawPayload;
+    }
+
+    const initTimeout =
+      this.options.defaultTimeoutMs > 0 ? this.options.defaultTimeoutMs : 10000;
+    const jsSessionId = generateUUID();
+
+    try {
+      const replyPayload = await this.sendRequest<BridgeMetadataPayload>(
+        OPERATIONS.INIT,
+        undefined,
+        {
+          bridgeName: this.endpoint.name,
+          clientVersion: CLIENT_VERSION,
+          sessionId: jsSessionId,
+        },
+        initTimeout,
+      );
+
+      if (!replyPayload || typeof replyPayload !== "object") {
+        throw new BridgeInitializationError(
+          `Initialization reply payload for endpoint "${this.endpoint.name}" is invalid or null.`,
+          this.endpoint.name,
+        );
+      }
+
+      const metadataPayload = replyPayload as BridgeMetadataPayload;
+
+      if (
+        !metadataPayload.protocolVersion ||
+        metadataPayload.protocolVersion !== PROTOCOL_VERSION
+      ) {
+        throw new BridgeInitializationError(
+          `Incompatible bridge protocol version: native reported version ${metadataPayload.protocolVersion}, expected ${PROTOCOL_VERSION}.`,
+          this.endpoint.name,
+        );
+      }
+
+      // Use native's returned sessionId if available, otherwise fall back to JS-generated sessionId
+      const finalSessionId =
+        metadataPayload.sessionId && metadataPayload.sessionId.trim() !== ""
+          ? metadataPayload.sessionId
+          : jsSessionId;
+
+      const normalizedMetadata: BridgeMetadataPayload = {
+        ...metadataPayload,
+        sessionId: finalSessionId,
+      };
+
+      this.metadataRegistry = new MetadataRegistry(normalizedMetadata);
+      this.activeSessionId = finalSessionId;
+      return normalizedMetadata;
+    } catch (err) {
+      if (err instanceof BridgeError) {
+        throw err;
+      }
+      throw new BridgeInitializationError(
+        `Failed to initialize bridge transport for endpoint "${this.endpoint.name}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        this.endpoint.name,
+      );
+    }
+  }
+
+  public async invoke<T extends BridgeValue = BridgeValue>(
+    path: string,
+    args?: BridgeValue[],
+    timeoutMs?: number,
+  ): Promise<T> {
+    return this.sendRequest<T>(OPERATIONS.INVOKE, path, args ?? [], timeoutMs);
+  }
+
+  public async get<T extends BridgeValue = BridgeValue>(
+    path: string,
+    timeoutMs?: number,
+  ): Promise<T> {
+    return this.sendRequest<T>(OPERATIONS.GET, path, undefined, timeoutMs);
+  }
+
+  public async set(
+    path: string,
+    value: BridgeValue,
+    timeoutMs?: number,
+  ): Promise<void> {
+    await this.sendRequest<void>(OPERATIONS.SET, path, value, timeoutMs);
+  }
+
+  public onEvent<T = BridgeValue>(
+    eventName: string,
+    handler: BridgeEventHandler<T>,
+  ): () => void {
+    if (this.isDisposed) {
+      return () => {};
+    }
+
+    let subscribers = this.eventSubscribers.get(eventName);
+    if (!subscribers) {
+      subscribers = new Set();
+      this.eventSubscribers.set(eventName, subscribers);
+    }
+
+    const genericHandler = handler as unknown as BridgeEventHandler;
+    subscribers.add(genericHandler);
+
+    return () => {
+      const set = this.eventSubscribers.get(eventName);
+      if (set) {
+        set.delete(genericHandler);
+        if (set.size === 0) {
+          this.eventSubscribers.delete(eventName);
+        }
+      }
+    };
+  }
+
+  private async sendRequest<T>(
+    operation: "init" | "invoke" | "get" | "set",
+    path?: string,
+    payloadOrValueOrArgs?: unknown,
+    overrideTimeoutMs?: number,
+  ): Promise<T> {
+    if (this.isDisposed) {
+      throw new BridgeTransportError(
+        `Transport for endpoint "${this.endpoint.name}" is disposed.`,
+        this.endpoint.name,
+      );
+    }
+
+    const id = generateUUID();
+    const request = this.buildRequestObject(
+      operation,
+      id,
+      path,
+      payloadOrValueOrArgs,
+    );
+    const rawMessage = encodeBridgeMessage(request);
+
+    const timeoutMs = overrideTimeoutMs ?? this.options.defaultTimeoutMs;
+
+    return new Promise<T>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      if (timeoutMs > 0) {
+        timer = setTimeout(() => {
+          this.pendingRequests.delete(id);
+          reject(new BridgeTimeoutError(id, timeoutMs));
+        }, timeoutMs);
+      }
+
+      this.pendingRequests.set(id, {
+        resolve: (val: unknown) => {
+          if (timer) clearTimeout(timer);
+          resolve(val as T);
+        },
+        reject: (err: BridgeError) => {
+          if (timer) clearTimeout(timer);
+          reject(err);
+        },
+        timer,
+      });
+
+      try {
+        this.endpoint.postMessage(rawMessage);
+      } catch (err) {
+        this.pendingRequests.delete(id);
+        if (timer) clearTimeout(timer);
+        reject(
+          new BridgeTransportError(
+            `Failed to transmit message over endpoint "${this.endpoint.name}": ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            this.endpoint.name,
+          ),
+        );
+      }
+    });
+  }
+
+  private buildRequestObject(
+    operation: "init" | "invoke" | "get" | "set",
+    id: string,
+    path?: string,
+    payloadOrValueOrArgs?: unknown,
+  ): BridgeRequest {
+    if (operation === OPERATIONS.INIT) {
+      const payloadObj = payloadOrValueOrArgs as BridgeInitPayload;
+      const initReq: BridgeInitRequest = {
+        type: MESSAGE_TYPES.REQUEST,
+        operation: OPERATIONS.INIT,
+        id,
+        protocolVersion: PROTOCOL_VERSION,
+        payload: {
+          bridgeName: payloadObj.bridgeName,
+          clientVersion: payloadObj.clientVersion,
+          sessionId: payloadObj.sessionId,
+        },
+      };
+      return initReq;
+    }
+
+    if (operation === OPERATIONS.INVOKE) {
+      return {
+        type: MESSAGE_TYPES.REQUEST,
+        operation: OPERATIONS.INVOKE,
+        id,
+        payload: {
+          path: path ?? "",
+          args: (payloadOrValueOrArgs as BridgeValue[]) ?? [],
+          sessionId: this.activeSessionId ?? undefined,
+        },
+      };
+    }
+
+    if (operation === OPERATIONS.GET) {
+      return {
+        type: MESSAGE_TYPES.REQUEST,
+        operation: OPERATIONS.GET,
+        id,
+        payload: {
+          path: path ?? "",
+          sessionId: this.activeSessionId ?? undefined,
+        },
+      };
+    }
+
+    // set operation
+    return {
+      type: MESSAGE_TYPES.REQUEST,
+      operation: OPERATIONS.SET,
+      id,
+      payload: {
+        path: path ?? "",
+        value: payloadOrValueOrArgs as BridgeValue,
+        sessionId: this.activeSessionId ?? undefined,
+      },
+    };
+  }
+
+  private attachEndpointListener(): void {
+    this.endpointUnsubscribe = this.endpoint.onMessage((rawMessage: string) => {
+      this.handleIncomingRawMessage(rawMessage);
+    });
+  }
+
+  private handleIncomingRawMessage(rawMessage: string): void {
+    if (this.isDisposed) {
+      return;
+    }
+
+    const decoded = decodeBridgeMessage(rawMessage);
+    if (!decoded) {
+      // Ignore invalid or unparseable JSON silently
+      return;
+    }
+
+    if (isBridgeReply(decoded)) {
+      this.processReply(decoded);
+    } else if (isBridgeEvent(decoded)) {
+      this.processEvent(decoded);
+    }
+  }
+
+  private processReply(reply: BridgeReply): void {
+    const pending = this.pendingRequests.get(reply.id);
+    if (!pending) {
+      return;
+    }
+
+    this.pendingRequests.delete(reply.id);
+
+    if (reply.status === REPLY_STATUS.ERROR || reply.error) {
+      const errorPayload = reply.error ?? {
+        code: "NATIVE_ERROR",
+        message: "Native reported error status without payload.",
+      };
+      pending.reject(
+        new BridgeNativeError(
+          errorPayload.message,
+          errorPayload.code,
+          errorPayload.details,
+        ),
+      );
+    } else if (
+      reply.type === MESSAGE_TYPES.ACK ||
+      reply.status === REPLY_STATUS.ACK ||
+      (reply.status === REPLY_STATUS.SUCCESS && reply.result === undefined)
+    ) {
+      // Void return type resolves cleanly to undefined (void in JS/TS)
+      pending.resolve(undefined);
+    } else {
+      // Explicit value return type (including null, string, number, object, array, boolean)
+      pending.resolve(reply.result);
+    }
+  }
+
+  private processEvent(event: BridgeEvent): void {
+    const subscribers = this.eventSubscribers.get(event.name);
+    if (!subscribers || subscribers.size === 0) {
+      return;
+    }
+
+    for (const handler of Array.from(subscribers)) {
+      try {
+        handler(event.payload);
+      } catch {
+        // Isolate subscriber execution errors
+      }
+    }
+  }
+
+  public dispose(): void {
+    if (this.isDisposed) {
+      return;
+    }
+    this.isDisposed = true;
+
+    if (this.endpointUnsubscribe) {
+      this.endpointUnsubscribe();
+      this.endpointUnsubscribe = null;
+    }
+
+    for (const pending of this.pendingRequests.values()) {
+      if (pending.timer) clearTimeout(pending.timer);
+      pending.reject(
+        new BridgeTransportError(
+          `Native transport for endpoint "${this.endpoint.name}" was disposed.`,
+          this.endpoint.name,
+        ),
+      );
+    }
+
+    this.pendingRequests.clear();
+    this.eventSubscribers.clear();
+    this.metadataRegistry = null;
+  }
+}

--- a/packages/webview-bridge/src/transport/native-transport.ts
+++ b/packages/webview-bridge/src/transport/native-transport.ts
@@ -113,7 +113,6 @@ export class DefaultNativeTransport implements NativeTransport {
     if (this.isDisposed) {
       throw new BridgeTransportError(
         `Transport for endpoint "${this.endpoint.name}" is disposed.`,
-        this.endpoint.name,
       );
     }
 
@@ -140,7 +139,6 @@ export class DefaultNativeTransport implements NativeTransport {
       if (!replyPayload || typeof replyPayload !== "object") {
         throw new BridgeInitializationError(
           `Initialization reply payload for endpoint "${this.endpoint.name}" is invalid or null.`,
-          this.endpoint.name,
         );
       }
 
@@ -152,7 +150,6 @@ export class DefaultNativeTransport implements NativeTransport {
       ) {
         throw new BridgeInitializationError(
           `Incompatible bridge protocol version: native reported version ${metadataPayload.protocolVersion}, expected ${PROTOCOL_VERSION}.`,
-          this.endpoint.name,
         );
       }
 
@@ -178,7 +175,6 @@ export class DefaultNativeTransport implements NativeTransport {
         `Failed to initialize bridge transport for endpoint "${this.endpoint.name}": ${
           err instanceof Error ? err.message : String(err)
         }`,
-        this.endpoint.name,
       );
     }
   }
@@ -243,7 +239,6 @@ export class DefaultNativeTransport implements NativeTransport {
     if (this.isDisposed) {
       throw new BridgeTransportError(
         `Transport for endpoint "${this.endpoint.name}" is disposed.`,
-        this.endpoint.name,
       );
     }
 
@@ -290,7 +285,6 @@ export class DefaultNativeTransport implements NativeTransport {
             `Failed to transmit message over endpoint "${this.endpoint.name}": ${
               err instanceof Error ? err.message : String(err)
             }`,
-            this.endpoint.name,
           ),
         );
       }
@@ -445,7 +439,6 @@ export class DefaultNativeTransport implements NativeTransport {
       pending.reject(
         new BridgeTransportError(
           `Native transport for endpoint "${this.endpoint.name}" was disposed.`,
-          this.endpoint.name,
         ),
       );
     }
@@ -453,5 +446,8 @@ export class DefaultNativeTransport implements NativeTransport {
     this.pendingRequests.clear();
     this.eventSubscribers.clear();
     this.metadataRegistry = null;
+
+    // Clean up underlying endpoint (removes window message listeners and callback properties)
+    this.endpoint.dispose();
   }
 }

--- a/packages/webview-bridge/src/transport/types.d.ts
+++ b/packages/webview-bridge/src/transport/types.d.ts
@@ -1,0 +1,81 @@
+import type {
+  BridgeMetadataPayload,
+  BridgeValue,
+} from "../protocol/types.d.ts";
+
+/**
+ * Event handler callback for native events.
+ */
+export type BridgeEventHandler<T = BridgeValue> = (payload: T) => void;
+
+/**
+ * Options for configuring NativeTransport behavior.
+ */
+export interface NativeTransportOptions {
+  /**
+   * Optional default timeout duration in milliseconds for pending requests.
+   * If set to 0 or undefined, requests do not time out by default, allowing
+   * long-running native operations (e.g. downloadFile) to complete.
+   */
+  defaultTimeoutMs?: number;
+}
+
+/**
+ * Driver-level protocol transport interface.
+ * Handles request IDs, promise correlation, timeouts, JSON serialization,
+ * event dispatching, session state, and metadata retrieval.
+ */
+export interface NativeTransport {
+  /** Endpoint registration name */
+  readonly endpointName: string;
+
+  /** Active session ID established during initialization handshake */
+  readonly sessionId: string | null;
+
+  /** Metadata describing native capabilities */
+  readonly metadata: BridgeMetadataPayload | null;
+
+  /** Whether the transport has completed initialization handshake */
+  readonly isInitialized: boolean;
+
+  /**
+   * Performs the initial protocol handshake to establish session and retrieve capability metadata.
+   */
+  initialize(): Promise<BridgeMetadataPayload>;
+
+  /**
+   * Invokes a native function capability asynchronously.
+   */
+  invoke<T extends BridgeValue = BridgeValue>(
+    path: string,
+    args?: BridgeValue[],
+    timeoutMs?: number,
+  ): Promise<T>;
+
+  /**
+   * Reads a native property capability asynchronously.
+   */
+  get<T extends BridgeValue = BridgeValue>(
+    path: string,
+    timeoutMs?: number,
+  ): Promise<T>;
+
+  /**
+   * Writes a native property capability asynchronously. Resolves when acknowledged by native.
+   */
+  set(path: string, value: BridgeValue, timeoutMs?: number): Promise<void>;
+
+  /**
+   * Subscribes a listener to unsolicited native events by event name.
+   * Returns an unsubscribe function.
+   */
+  onEvent<T = BridgeValue>(
+    eventName: string,
+    handler: BridgeEventHandler<T>,
+  ): () => void;
+
+  /**
+   * Disposes the transport, cancelling pending requests and tearing down endpoint listeners.
+   */
+  dispose(): void;
+}

--- a/packages/webview-bridge/tsconfig.json
+++ b/packages/webview-bridge/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Add the new WebView-to-native bridge library for consistent JavaScript communication with native Android and iOS APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a platform-independent native WebView bridge for Android and iOS.
  - Supports automatic platform detection, native function calls, property reads and writes, event subscriptions, capability metadata, sessions, timeouts, and structured errors.
  - Gracefully handles unavailable capabilities and missing native endpoints.
  - Added reliable request handling and cleanup across supported WebView environments.

- **Bug Fixes**
  - Improved preservation of existing message handlers and resolution of native communication failures.

- **Documentation**
  - Added package documentation covering setup, supported platforms, API usage, protocol behavior, and development guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->