### PR TITLE
fix(api): allow non-interactive instructor resolution

### DIFF
--- a/apps/api/src/cli/import-youtube.ts
+++ b/apps/api/src/cli/import-youtube.ts
@@ -953,7 +953,7 @@ async function ensureYtDlpBinary(
 async function resolveInstructor(
   database: ReturnType<typeof createDatabase>,
   inputEmail: string | undefined,
-  rl: readline.Interface,
+  rl?: readline.Interface,
 ) {
   const email = inputEmail?.trim().toLowerCase();
 


### PR DESCRIPTION
## Summary

Fixes the API TypeScript build failure after merging the course overview changes into `development`.

## Problem

The YouTube import CLI passed `undefined` for the readline interface when running in non-interactive `--yes` mode, but `resolveInstructor` required a non-optional `readline.Interface`.

## Fix

- Made the `readline.Interface` parameter optional.
- Preserved interactive instructor selection when readline is available.
- Preserved automatic first-instructor selection for non-interactive mode.

## Validation

- `pnpm --filter @veolms/api typecheck` passes.
- No changes to runtime behavior for interactive imports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Non-interactive YouTube imports can now proceed without prompting for an instructor, automatically selecting the first available instructor or administrator when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->