### PR TITLE
fix(config) add S3 credentials and endpoints to various services

### DIFF
--- a/apps/api/src/lib/lambda.ts
+++ b/apps/api/src/lib/lambda.ts
@@ -5,16 +5,20 @@ let clientInstance: LambdaClient | null = null;
 
 export function getLambdaClient(): LambdaClient {
   if (!clientInstance) {
+    const accessKeyId = config.FLEET_MANAGER_ACCESS_KEY_ID;
+    const secretAccessKey = config.FLEET_MANAGER_SECRET_ACCESS_KEY;
+
     clientInstance = new LambdaClient({
       region: config.FLEET_MANAGER_LAMBDA_REGION || config.STORAGE_REGION,
       credentials:
-        config.STORAGE_ACCESS_KEY_ID && config.STORAGE_SECRET_ACCESS_KEY
+        accessKeyId && secretAccessKey
           ? {
-              accessKeyId: config.STORAGE_ACCESS_KEY_ID,
-              secretAccessKey: config.STORAGE_SECRET_ACCESS_KEY,
+              accessKeyId,
+              secretAccessKey,
             }
           : undefined,
     });
   }
+
   return clientInstance;
 }

--- a/apps/fleet-manager/src/core/video-job-manager.ts
+++ b/apps/fleet-manager/src/core/video-job-manager.ts
@@ -871,10 +871,17 @@ export function createJobManager(options: {
           storage ??
           new S3StorageService({
             bucket,
-            region: process.env.AWS_REGION || "us-east-1",
+            region:
+              process.env.S3_REGION || process.env.AWS_REGION || "us-east-1",
             endpoint:
-              process.env.AWS_ENDPOINT_URL || process.env.LOCALSTACK_ENDPOINT,
-            forcePathStyle: Boolean(process.env.AWS_ENDPOINT_URL),
+              process.env.S3_ENDPOINT ||
+              process.env.AWS_ENDPOINT_URL ||
+              process.env.LOCALSTACK_ENDPOINT,
+            accessKeyId: process.env.S3_ACCESS_KEY_ID,
+            secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+            forcePathStyle:
+              process.env.S3_FORCE_PATH_STYLE === "true" ||
+              Boolean(process.env.AWS_ENDPOINT_URL),
           });
 
         try {

--- a/apps/media-worker/src/processor.ts
+++ b/apps/media-worker/src/processor.ts
@@ -457,6 +457,8 @@ export async function executeTranscodeJob(
       bucket: config.S3_BUCKET,
       region: config.S3_REGION,
       endpoint: config.S3_ENDPOINT,
+      accessKeyId: config.S3_ACCESS_KEY_ID,
+      secretAccessKey: config.S3_SECRET_ACCESS_KEY,
       forcePathStyle: config.S3_FORCE_PATH_STYLE,
     });
     await mkdir(jobScratchDir, { recursive: true });

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -145,6 +145,8 @@ const serverConfigSchema = z.object({
   PROBE_LAMBDA_NAME: z.string().optional(),
   FLEET_MANAGER_LAMBDA_REGION: z.string().optional(),
   FLEET_MANAGER_HEARTBEAT_SECONDS: z.coerce.number().int().min(1).default(10),
+  FLEET_MANAGER_ACCESS_KEY_ID: z.string().optional(),
+  FLEET_MANAGER_SECRET_ACCESS_KEY: z.string().optional(),
 
   // Razorpay Gateway
   RAZORPAY_KEY_ID: z.string().optional(),

--- a/packages/config/src/media-worker.ts
+++ b/packages/config/src/media-worker.ts
@@ -53,6 +53,8 @@ const baseMediaWorkerConfigSchema = z.object({
   S3_BUILD_BUCKET: z.string().optional(),
   S3_ENDPOINT: z.string().optional(),
   S3_REGION: z.string().default("us-east-1"),
+  S3_ACCESS_KEY_ID: z.string().optional(),
+  S3_SECRET_ACCESS_KEY: z.string().optional(),
   AWS_REGION: z.string().optional(),
   S3_FORCE_PATH_STYLE: z
     .enum(["true", "false"])

--- a/packages/fleet-provider-aws/src/probe-lambda.ts
+++ b/packages/fleet-provider-aws/src/probe-lambda.ts
@@ -267,6 +267,17 @@ export async function processProbeAndForward(
     process.env["S3_BUCKET"] ??
     process.env["STORAGE_BUCKET"];
 
+  const s3Endpoint =
+    process.env["S3_ENDPOINT"] ||
+    process.env["AWS_ENDPOINT_URL"] ||
+    process.env["LOCALSTACK_ENDPOINT"];
+  const s3AccessKeyId = process.env["S3_ACCESS_KEY_ID"];
+  const s3SecretAccessKey = process.env["S3_SECRET_ACCESS_KEY"];
+  const s3Credentials =
+    s3AccessKeyId && s3SecretAccessKey
+      ? { accessKeyId: s3AccessKeyId, secretAccessKey: s3SecretAccessKey }
+      : undefined;
+
   const endpoint =
     process.env["AWS_ENDPOINT_URL"] || process.env["LOCALSTACK_ENDPOINT"];
   const lambda =
@@ -278,8 +289,16 @@ export async function processProbeAndForward(
   const s3 =
     customConfig.s3Client ??
     new S3Client({
-      region,
-      ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
+      region: process.env["S3_REGION"] || region,
+      ...(s3Endpoint
+        ? {
+            endpoint: s3Endpoint,
+            forcePathStyle:
+              process.env["S3_FORCE_PATH_STYLE"] === "true" ||
+              Boolean(process.env["AWS_ENDPOINT_URL"]),
+          }
+        : {}),
+      ...(s3Credentials ? { credentials: s3Credentials } : {}),
     });
 
   if (payload.status === "cancelled") {

--- a/packages/fleet-provider-aws/src/provider.ts
+++ b/packages/fleet-provider-aws/src/provider.ts
@@ -148,7 +148,27 @@ export function createAwsProvider(
 
   const ec2 = config.ec2Client ?? new EC2Client({ region });
   const ssm = config.ssmClient ?? new SSMClient({ region });
-  const s3 = config.s3Client ?? new S3Client({ region });
+  const s3Endpoint = process.env.S3_ENDPOINT || process.env.AWS_ENDPOINT_URL;
+  const s3AccessKeyId = process.env.S3_ACCESS_KEY_ID;
+  const s3SecretAccessKey = process.env.S3_SECRET_ACCESS_KEY;
+  const s3Credentials =
+    s3AccessKeyId && s3SecretAccessKey
+      ? { accessKeyId: s3AccessKeyId, secretAccessKey: s3SecretAccessKey }
+      : undefined;
+  const s3 =
+    config.s3Client ??
+    new S3Client({
+      region: process.env.S3_REGION || region,
+      ...(s3Endpoint
+        ? {
+            endpoint: s3Endpoint,
+            forcePathStyle:
+              process.env.S3_FORCE_PATH_STYLE === "true" ||
+              Boolean(process.env.AWS_ENDPOINT_URL),
+          }
+        : {}),
+      ...(s3Credentials ? { credentials: s3Credentials } : {}),
+    });
   const schedulerManager =
     config.schedulerManager ??
     createAwsSchedulerManager({
@@ -198,6 +218,17 @@ export function createAwsProvider(
         FLEET_TEST_MODE: process.env.FLEET_TEST_MODE ?? "false",
         ...(bucketName ? { S3_BUCKET: bucketName } : {}),
         ...(buildBucket ? { S3_BUILD_BUCKET: buildBucket } : {}),
+        ...(process.env.S3_ENDPOINT ? { S3_ENDPOINT: process.env.S3_ENDPOINT } : {}),
+        ...(process.env.S3_REGION ? { S3_REGION: process.env.S3_REGION } : {}),
+        ...(process.env.S3_ACCESS_KEY_ID
+          ? { S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID }
+          : {}),
+        ...(process.env.S3_SECRET_ACCESS_KEY
+          ? { S3_SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY }
+          : {}),
+        ...(process.env.S3_FORCE_PATH_STYLE
+          ? { S3_FORCE_PATH_STYLE: process.env.S3_FORCE_PATH_STYLE }
+          : {}),
         ...config.defaultEnv,
       };
 

--- a/packages/fleet-provider-docker/src/provider.ts
+++ b/packages/fleet-provider-docker/src/provider.ts
@@ -156,6 +156,21 @@ function buildWorkerEnvironment(options: {
     ...(databaseUrl
       ? { DATABASE_URL: databaseUrl }
       : {}),
+    ...(process.env.STORAGE_PROVIDER
+      ? { STORAGE_PROVIDER: process.env.STORAGE_PROVIDER }
+      : {}),
+    ...(process.env.S3_BUCKET ? { S3_BUCKET: process.env.S3_BUCKET } : {}),
+    ...(process.env.S3_ENDPOINT ? { S3_ENDPOINT: process.env.S3_ENDPOINT } : {}),
+    ...(process.env.S3_REGION ? { S3_REGION: process.env.S3_REGION } : {}),
+    ...(process.env.S3_ACCESS_KEY_ID
+      ? { S3_ACCESS_KEY_ID: process.env.S3_ACCESS_KEY_ID }
+      : {}),
+    ...(process.env.S3_SECRET_ACCESS_KEY
+      ? { S3_SECRET_ACCESS_KEY: process.env.S3_SECRET_ACCESS_KEY }
+      : {}),
+    ...(process.env.S3_FORCE_PATH_STYLE
+      ? { S3_FORCE_PATH_STYLE: process.env.S3_FORCE_PATH_STYLE }
+      : {}),
     WORKER_ID: options.workerId,
     PROVIDER: "docker",
     LOCAL_STORAGE_ROOT: "/app/s3-bucket",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring S3-compatible storage with custom endpoints, regions, credentials, and path-style addressing.
  - Extended worker and processing services to use dedicated S3 access credentials and storage settings.
  - Added optional Fleet Manager credentials for Lambda access.
  - S3 configuration is now consistently forwarded to worker processes across AWS and Docker deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->